### PR TITLE
Restrict TLS to v.1 and allow only TLS ciphers

### DIFF
--- a/src/github.com/mozilla-services/pushgo/simplepush/net.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/net.go
@@ -117,7 +117,8 @@ func ListenTLS(addr, certFile, keyFile string, maxConns int, keepAlivePeriod tim
 		NextProtos:   []string{"http/1.1"},
 		Certificates: []tls.Certificate{cert},
 		// The following are Mozilla required TLS settings.
-		MinVersion: tls.VersionTLS10,
+		MinVersion:               tls.VersionTLS10,
+		PreferServerCipherSuites: true,
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,


### PR DESCRIPTION
r+'s by ulfr
@kitcambridge r? to make sure that i got all the TLS config points.

```
09:17 < ulfr> jrconlin: the cipher thing should be easy enough:
              config.MinVersion = 0x0301 and config.CipherSuites =
              [...]uint16{0xc02f, 0xc02b, 0xc013, 0xc014, 0xc00a, 0xc009,
              0x002f, 0x0035, 0xc012, 0x000a}
09:17 < jrconlin> jbonacci: I did, I even brought along some friends to help
                  swear.
09:18 < jrconlin> ulfr: thanks, I'll see about adding those.
09:18 < ulfr> I'm testing locally to make sure the ciphersuite works
09:18 < jrconlin> cool.
09:35 < jrconlin> ulfr: will probably use config.MinVersion=tls.VersionTLS10;
                  it's better being readable.
09:45 < jrconlin> also spelling out the ciphers.
10:04 < ulfr> jrconlin: https://linuxwall.info/p/pbUf
10:04 < ulfr> jrconlin: there's also a boolean to set to prefer the server
              ordering, see line 42
10:05 < jrconlin> ulfr: yeah, noticed that when I was digging through the tls
                  stuff.
10:05 < jrconlin> May I ask why you're appending the extra ciphers rather than
                  specifying them in the config?
10:06 < ulfr> jrconlin: quickndirty code written during meetings :p
10:06 < jrconlin> gotcha.
10:08 < jrconlin> ulfr: will apply the following:
                  http://pastebin.mozilla.org/6799504 r?
10:12 < ulfr> jrconlin: r+ https://linuxwall.info/p/F58z
```
