### PR TITLE
Add /status/ endpoint to websocket client mux

### DIFF
--- a/src/github.com/mozilla-services/pushgo/simplepush/app.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/app.go
@@ -164,6 +164,7 @@ func (a *Application) Run() (errChan chan error) {
 	errChan = make(chan error)
 
 	clientMux := mux.NewRouter()
+	clientMux.HandleFunc("/status/", a.handlers.StatusHandler)
 	clientMux.Handle("/", websocket.Server{Handler: a.handlers.PushSocketHandler,
 		Handshake: a.checkOrigin})
 


### PR DESCRIPTION
This is useful for monitoring the push endpoint separately from the
update endpoint.
