### PR TITLE
SSL Patch for v1.1

### DIFF
--- a/src/mozilla.org/util/heka_log.go
+++ b/src/mozilla.org/util/heka_log.go
@@ -5,7 +5,6 @@
 package util
 
 import (
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/mozilla-services/heka/client"
 	"github.com/mozilla-services/heka/message"
 
@@ -16,7 +15,6 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
-	"time"
 )
 
 type HekaLogger struct {
@@ -153,42 +151,6 @@ func (self HekaLogger) Log(level int32, mtype, payload string, fields Fields) (e
 		}
 		log.Printf(dump)
 
-		// Don't send an error if there's nothing to do
-		if self.sender == nil {
-			return nil
-		}
-
-		var stream []byte
-
-		msg := &message.Message{}
-		msg.SetTimestamp(time.Now().UnixNano())
-		msg.SetUuid(uuid.NewRandom())
-		msg.SetLogger(self.logname)
-		msg.SetType(mtype)
-		msg.SetPid(self.pid)
-		msg.SetSeverity(level)
-		msg.SetHostname(self.hostname)
-		if len(payload) > 0 {
-			msg.SetPayload(payload)
-		}
-		err = addFields(msg, fields)
-		if err != nil {
-			return err
-		}
-		err = addFields(msg, caller)
-		if err != nil {
-			return err
-		}
-		err = self.encoder.EncodeMessageStream(msg, &stream)
-		if err != nil {
-			log.Fatal("ERROR: Could not encode log message: " + err.Error())
-			return err
-		}
-		err = self.sender.SendMessage(stream)
-		if err != nil {
-			log.Fatal("ERROR: Could not send message: ", err.Error())
-			return err
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
- Remove old heka code (no longer used or supported)
- Add TLS patch to revoke SSLv3 access.

r? @kitcambridge 
