### PR TITLE
Routing goes down here after storage and such have been done.

### DIFF
--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers.go
@@ -297,7 +297,6 @@ sendUpdate:
 		http.Error(resp, "Could not update channel version", status)
 		return
 	}
-	self.metrics.Increment("updates.appserver.received")
 
 	// Ping the appropriate server
 	// Is this ours or should we punt to a different server?
@@ -319,6 +318,7 @@ sendUpdate:
 	if clientConnected {
 		self.app.Server().RequestFlush(client, chid, int64(version))
 	}
+	self.metrics.Increment("updates.appserver.received")
 	resp.Header().Set("Content-Type", "application/json")
 	resp.Write([]byte("{}"))
 	return


### PR DESCRIPTION
Fix so that routing a message doesn't ignore everything else that should be done.... like prop ping, etc.
