### PR TITLE
Add /realstatus/ to clientMux

### DIFF
--- a/src/github.com/mozilla-services/pushgo/simplepush/app.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/app.go
@@ -166,6 +166,7 @@ func (a *Application) Run() (errChan chan error) {
 
 	clientMux := mux.NewRouter()
 	clientMux.HandleFunc("/status/", a.handlers.StatusHandler)
+	clientMux.HandleFunc("/realstatus/", a.handlers.RealStatusHandler)
 	clientMux.Handle("/", websocket.Server{Handler: a.handlers.PushSocketHandler,
 		Handshake: a.checkOrigin})
 


### PR DESCRIPTION
When we switch over to using /realstatus/ for monitoring, we'll need to hit it on the websocket endpoint as well.
