### PR TITLE
Restore `AlwaysUpdate`; add update handler tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,8 @@ Features
     idle_conns
 - Always route option, allows the router to always attempt to route a message
   before checking local clients. This can be useful to increase message
-  delivery reliability at the expense of some additional routing. PR #116.
+  delivery reliability at the expense of some additional routing.
+  PR #116, #192.
     always_route
 - Weighted Load balancing via redirect using etcd. pushgo can now store client
   counts in etcd and utilize counts to do a weighted redirect during a client's
@@ -76,6 +77,8 @@ Metrics
     'balancer.fetch.success', 'balancer.publish.retry'
     'balancer.publish.error', 'balancer.publish.success'
     'balancer.etcd.error', 'balancer.etcd.retry'
+- A counter that tracks failed local delivery attempts:
+    'updates.appserver.rejected'
 
 Incompatibilities
 -----------------
@@ -119,6 +122,8 @@ Internal
 - The router now uses a goroutine per notification instead of a goroutine pool.
   This ensures slow requests don't delay other requests. PR #167.
 - The Heka client dependency has been removed. PR #161, Issue #125.
+- The router now indicates whether a routed message was accepted by a peer, to
+  support the 'always_route' option. PR #192.
 
 1.4.2
 =====

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -61,6 +61,12 @@ addr = ":8080"
 [endpoint]
 # Maximum allowed data segment (in bytes)
 #max_data_len = 4096
+# Always route. This will force a server to always send a message out for
+# routing, even if the server believes that the client is connected. This
+# is useful in cases where a client may have reconnected to a different
+# server but the old connection has yet to time out for the server. (This,
+# sadly, happens a fair bit.)
+#always_route = false
 
 [endpoint.listener]
 addr = ":8081"

--- a/src/github.com/mozilla-services/pushgo/simplepush/emcee_store.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/emcee_store.go
@@ -421,11 +421,7 @@ func (s *EmceeStore) storeUpdate(uaid, chid string, version int64) error {
 
 // Update updates the version for the given device ID and channel ID.
 // Implements Store.Update().
-func (s *EmceeStore) Update(key string, version int64) (err error) {
-	uaid, chid, ok := s.KeyToIDs(key)
-	if !ok {
-		return ErrInvalidKey
-	}
+func (s *EmceeStore) Update(uaid, chid string, version int64) (err error) {
 	if len(uaid) == 0 {
 		return ErrNoID
 	}

--- a/src/github.com/mozilla-services/pushgo/simplepush/error.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/error.go
@@ -38,8 +38,13 @@ const (
 	ErrNonexistentRecord  ErrorCode = 115
 	ErrRecordUpdateFailed ErrorCode = 116
 	ErrBadPayload         ErrorCode = 117
-	ErrTooManyPings       ErrorCode = 201
-	ErrServerError        ErrorCode = 999
+
+	ErrTooManyPings ErrorCode = 201
+
+	ErrBadVersion  ErrorCode = 301
+	ErrDataTooLong ErrorCode = 302
+
+	ErrServerError ErrorCode = 999
 )
 
 // Error returns a human-readable error message.

--- a/src/github.com/mozilla-services/pushgo/simplepush/gomemc_store.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/gomemc_store.go
@@ -303,11 +303,7 @@ func (s *GomemcStore) storeUpdate(uaid, chid string, version int64) error {
 
 // Update updates the version for the given device ID and channel ID.
 // Implements Store.Update().
-func (s *GomemcStore) Update(key string, version int64) (err error) {
-	uaid, chid, ok := s.KeyToIDs(key)
-	if !ok {
-		return ErrInvalidKey
-	}
+func (s *GomemcStore) Update(uaid, chid string, version int64) (err error) {
 	if len(uaid) == 0 {
 		return ErrNoID
 	}

--- a/src/github.com/mozilla-services/pushgo/simplepush/gomemc_store_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/gomemc_store_test.go
@@ -210,26 +210,23 @@ func Test_Update(t *testing.T) {
 		t.Skip("Skipping, no server.")
 	}
 
-	var err error
-	validKey, _ := testGm.IDsToKey(TESTUAID, TESTCHID)
-
-	err = testGm.Update(validKey, 12345)
+	err := testGm.Update(TESTUAID, TESTCHID, 12345)
 	if err != nil {
 		t.Errorf("Update returned error: %v", err)
 	}
-	err = testGm.Update("."+TESTCHID, 12345)
+	err = testGm.Update("", TESTCHID, 12345)
 	if err == nil {
 		t.Error("Update failed to reject empty UAID")
 	}
-	err = testGm.Update(TESTUAID+".", 12345)
+	err = testGm.Update(TESTUAID, "", 12345)
 	if err == nil {
 		t.Error("Update failed to reject empty ChannelID")
 	}
-	err = testGm.Update("Invalid."+TESTCHID, 12345)
+	err = testGm.Update("Invalid", TESTCHID, 12345)
 	if err == nil {
 		t.Error("Update failed to reject invalid UAID")
 	}
-	err = testGm.Update(TESTUAID+".Invalid", 12345)
+	err = testGm.Update(TESTUAID, "Invalid", 12345)
 	if err == nil {
 		t.Error("Update failed to reject invalid ChannelID")
 	}

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
@@ -280,7 +280,8 @@ func (h *EndpointHandler) UpdateHandler(resp http.ResponseWriter, req *http.Requ
 	h.metrics.Increment("updates.appserver.incoming")
 
 	// is there a Proprietary Ping for this?
-	if updateSent, err = h.doPropPing(uaid, version, data); err != nil {
+	updateSent, err = h.doPropPing(uaid, version, data)
+	if err != nil {
 		if logWarning {
 			h.logger.Warn("handlers_endpoint", "Could not send proprietary ping",
 				LogFields{"rid": requestID, "uaid": uaid, "error": err.Error()})
@@ -346,7 +347,7 @@ func (h *EndpointHandler) deliver(cn http.CloseNotifier, uaid, chid string, vers
 	// If the device is not connected to this server, indicate whether routing
 	// was successful.
 	if !clientConnected {
-		return ok
+		return
 	}
 	// Try local delivery if routing failed.
 	err := h.app.Server().RequestFlush(client, chid, version, data)

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
@@ -293,7 +293,7 @@ sendUpdate:
 				"version": strconv.FormatInt(version, 10)})
 	}
 
-	if err = h.store.Update(pk, version); err != nil {
+	if err = h.store.Update(uaid, chid, version); err != nil {
 		if logWarning {
 			h.logger.Warn("handlers_endpoint", "Could not update channel", LogFields{
 				"rid":     requestID,

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
@@ -318,7 +318,7 @@ sendUpdate:
 		if cn, ok := resp.(http.CloseNotifier); ok {
 			cancelSignal = cn.CloseNotify()
 		}
-		if err = h.router.Route(cancelSignal, uaid, chid, version, time.Now().UTC(), requestID, data); err != nil {
+		if _, err = h.router.Route(cancelSignal, uaid, chid, version, time.Now().UTC(), requestID, data); err != nil {
 			resp.WriteHeader(http.StatusNotFound)
 			resp.Write([]byte("false"))
 			return

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
@@ -267,7 +267,6 @@ func (h *EndpointHandler) UpdateHandler(resp http.ResponseWriter, req *http.Requ
 	// (Note, this would allow us to use smarter FE proxies.)
 	token := mux.Vars(req)["key"]
 	if uaid, chid, err = h.resolvePK(token); err != nil {
-		// Note: dumping the []uint8 keys can produce terminal glitches
 		if logWarning {
 			h.logger.Warn("handlers_endpoint", "Invalid primary key for update",
 				LogFields{"error": err.Error(), "rid": requestID, "token": token})

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint_test.go
@@ -5,71 +5,602 @@
 package simplepush
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/rafrombrc/gomock/gomock"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestDeliver(t *testing.T) {
+type keyTest struct {
+	name     string
+	key      string
+	expected bool
+}
+
+func (t keyTest) Test() error {
+	actual := validPK(t.key)
+	if actual != t.expected {
+		return fmt.Errorf("On test %s, got %s; want %s", t.name, actual,
+			t.expected)
+	}
+	return nil
+}
+
+func formReader(vals url.Values) io.ReadCloser {
+	return ioutil.NopCloser(strings.NewReader(vals.Encode()))
+}
+
+func getJSON(header http.Header, body *bytes.Buffer) (*bytes.Buffer, bool) {
+	if header.Get("Content-Type") != "application/json" {
+		return nil, false
+	}
+	buf := new(bytes.Buffer)
+	if err := json.Compact(buf, body.Bytes()); err != nil {
+		return nil, false
+	}
+	return buf, true
+}
+
+func TestEndpointValidKey(t *testing.T) {
+	tests := []keyTest{
+		{"Hyphenated key", "bb817e78-c568-4780-90c3-471f3b74f055.29f72d42-7a2a-42e4-897b-dc2c8a7cb676", true},
+		{"Non-hyphenated key", "bb817e78c568478090c3471f3b74f055.29f72d427a2a42e4897bdc2c8a7cb676", true},
+		{"Non-hyphenated, case-insensitive key", "BB817E78C568478090C3471F3B74F055.29F72D427A2A42E4897BDC2C8A7CB676", true},
+		{"Valid Base64-encoded key", "u4F+eMVoR4CQw0cfO3TwVQ==.KfctQnoqQuSJe9wsiny2dg==", false},
+		{"Invalid UUID; valid key", "pQrS-tUv-1234.wXyZ-5678", true},
+		{"Non-alphanumeric characters", "\t\r\n", false},
+		{"Extraneous punctuators", "_=!@#$%^&*()[]", false},
+	}
+	for _, test := range tests {
+		if err := test.Test(); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestEndpointResolveKey(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	app := NewApplication()
-	app.hostname = "test"
-	app.clientMinPing = 10 * time.Second
-	app.clientHelloTimeout = 10 * time.Second
-	app.pushLongPongs = true
+	mckLogger := NewMockLogger(mockCtrl)
+	mckLogger.EXPECT().ShouldLog(gomock.Any()).Return(true).AnyTimes()
+	mckLogger.EXPECT().Log(gomock.Any(), gomock.Any(),
+		gomock.Any(), gomock.Any()).AnyTimes()
+
+	mckStat := NewMockStatistician(mockCtrl)
+	mckStore := NewMockStore(mockCtrl)
+
+	Convey("Endpoint tokens", t, func() {
+		app := NewApplication()
+		app.SetLogger(mckLogger)
+		app.SetMetrics(mckStat)
+		app.SetStore(mckStore)
+
+		Convey("Should return a 404 for invalid tokens", func() {
+			app.SetTokenKey("c3v0AlmmxXu_LSfdZY3l3eayLsIwkX48")
+			eh := NewEndpointHandler()
+			eh.setApp(app)
+			app.SetEndpointHandler(eh)
+
+			resp := httptest.NewRecorder()
+			req := &http.Request{
+				Method: "PUT",
+				Header: http.Header{},
+				URL: &url.URL{
+					Path: "/update/j1bqzFq9WiwFZbqay-y7xVlfSvtO1eY="}, // "123.456"
+			}
+			gomock.InOrder(
+				mckStore.EXPECT().KeyToIDs("123.456").Return("", "", false),
+				mckStat.EXPECT().Increment("updates.appserver.invalid"),
+			)
+			eh.ServeMux().ServeHTTP(resp, req)
+
+			So(resp.Code, ShouldEqual, 404)
+			body, isJSON := getJSON(resp.HeaderMap, resp.Body)
+			So(isJSON, ShouldBeTrue)
+			So(body.String(), ShouldEqual, `"Invalid Token"`)
+		})
+
+		Convey("Should not decode plaintext tokens", func() {
+			var err error
+
+			app.SetTokenKey("")
+			eh := NewEndpointHandler()
+			eh.setApp(app)
+			app.SetEndpointHandler(eh)
+
+			_, err = eh.decodePK("")
+			So(err, ShouldNotBeNil)
+
+			pk, err := eh.decodePK("123.456")
+			So(pk, ShouldEqual, "123.456")
+		})
+
+		Convey("Should normalize decoded tokens", func() {
+			app.SetTokenKey("LM1xDImCx0rB46LCnx-3v4-Iyfk1LeKJbx9wuvx_z3U=")
+			eh := NewEndpointHandler()
+			eh.setApp(app)
+			app.SetEndpointHandler(eh)
+
+			// Hyphenated IDs should be normalized.
+			uaid := "dbda2ba2-004c-491f-9e3d-c5950aee93de"
+			chid := "848cd568-3f2a-4108-9ce4-bd0d928ecad4"
+			// " \t%s.%s\r\n" % (uaid, chid)
+			encodedKey := "qfGSdZzwf20GXiYubmZfIXj11Rx4RGJujFsjSQGdF4LRBhHbB_vt3hdW7cRvL9Fq_t_guMBGkDgebOoa5gRd1GGLN-Cv6h5hkpRTbdju8Tk-hMyC91BP4CEres_8"
+
+			// decodePK should trim whitespace from encoded keys.
+			mckStore.EXPECT().KeyToIDs(
+				fmt.Sprintf("%s.%s", uaid, chid)).Return(uaid, chid, true)
+			actualUAID, actualCHID, err := eh.resolvePK(encodedKey)
+			So(err, ShouldBeNil)
+			So(actualUAID, ShouldEqual, uaid)
+			So(actualCHID, ShouldEqual, chid)
+		})
+
+		Convey("Should reject invalid tokens", func() {
+			var err error
+
+			app.SetTokenKey("IhnNwMNbsFWiafTXSgF4Ag==")
+			eh := NewEndpointHandler()
+			eh.setApp(app)
+			app.SetEndpointHandler(eh)
+
+			invalidKey := "b54QOw2omSWBiEq0IuyfBGxHBIR7AI9YhCMA0lP9" // "_=!@#$%^&*()[]"
+			uaid := "82398a648c834f8b838cb3945eceaf29"
+			chid := "af445ad07e5f46b7a6c858150fc5aa92"
+			validKey := fmt.Sprintf("%s.%s", uaid, chid)
+			encodedKey := "swKSH8P2qprRt5y0J4Wi7ybl-qzFv1j09WPOfuabpEJmVUqwUpxjprXc2R3Yw0ITbqc_Swntw9_EpCgo_XuRTn7Q7opQYoQUgMPhCgT0EGbK"
+
+			_, _, err = eh.resolvePK(invalidKey[:8])
+			So(err, ShouldNotBeNil)
+
+			_, _, err = eh.resolvePK(invalidKey)
+			So(err, ShouldNotBeNil)
+
+			mckStore.EXPECT().KeyToIDs(validKey).Return("", "", false)
+			_, _, err = eh.resolvePK(encodedKey)
+			So(err, ShouldNotBeNil)
+
+			mckStore.EXPECT().KeyToIDs(validKey).Return(uaid, "", true)
+			_, _, err = eh.resolvePK(encodedKey)
+			So(err, ShouldNotBeNil)
+
+			mckStore.EXPECT().KeyToIDs(validKey).Return(uaid, chid, true)
+			actualUAID, actualCHID, err := eh.resolvePK(encodedKey)
+			So(err, ShouldBeNil)
+			So(actualUAID, ShouldEqual, uaid)
+			So(actualCHID, ShouldEqual, chid)
+		})
+	})
+}
+
+func TestEndpointContentType(t *testing.T) {
+	Convey("Content type handling", t, func() {
+		app := NewApplication()
+		eh := NewEndpointHandler()
+		eh.setApp(app)
+		eh.maxDataLen = 4096
+		app.SetEndpointHandler(eh)
+
+		Convey("Should supply a content type if omitted", func() {
+			vals := make(url.Values)
+			vals.Set("version", "123")
+			vals.Set("data", randomText(eh.maxDataLen))
+
+			version, data, err := eh.getUpdateParams(&http.Request{
+				Method: "PUT",
+				Header: http.Header{"Content-Type": {""}},
+				URL:    &url.URL{Path: "/update/123"},
+				Body:   formReader(vals),
+			})
+			So(err, ShouldBeNil)
+			So(version, ShouldEqual, 123)
+			So(len(data), ShouldEqual, eh.maxDataLen)
+		})
+
+		Convey("Should use query params if the body is omitted", func() {
+			version, data, err := eh.getUpdateParams(&http.Request{
+				Method: "PUT",
+				Header: http.Header{},
+				URL: &url.URL{
+					Path:     "/update/123",
+					RawQuery: "version=7&data=Hello%2C%20world!",
+				},
+			})
+			So(err, ShouldBeNil)
+			So(version, ShouldEqual, 7)
+			So(data, ShouldEqual, "Hello, world!")
+		})
+
+		Convey("Should accept multipart forms", func() {
+			buf := new(bytes.Buffer)
+			mw := multipart.NewWriter(buf)
+			mw.SetBoundary("db74d732")
+			mw.WriteField("version", "123")
+			mw.WriteField("data", "Hello, world!")
+			mw.Close()
+
+			version, data, err := eh.getUpdateParams(&http.Request{
+				Method: "PUT",
+				Header: http.Header{"Content-Type": {
+					"multipart/form-data; boundary=db74d732"}},
+				URL:  &url.URL{Path: "/update/123"},
+				Body: ioutil.NopCloser(buf),
+			})
+			So(err, ShouldBeNil)
+			So(version, ShouldEqual, 123)
+			So(data, ShouldEqual, "Hello, world!")
+		})
+	})
+}
+
+func TestEndpointInvalidParams(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
 
 	mckLogger := NewMockLogger(mockCtrl)
 	mckLogger.EXPECT().ShouldLog(gomock.Any()).Return(true).AnyTimes()
-	mckLogger.EXPECT().Log(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	app.SetLogger(mckLogger)
+	mckLogger.EXPECT().Log(gomock.Any(), gomock.Any(),
+		gomock.Any(), gomock.Any()).AnyTimes()
 
 	mckStat := NewMockStatistician(mockCtrl)
-	mckStat.EXPECT().Gauge("update.client.connections", gomock.Any()).AnyTimes()
-	app.SetMetrics(mckStat)
 
-	mckStore := NewMockStore(mockCtrl)
-	app.SetStore(mckStore)
+	Convey("Invalid update parameters", t, func() {
+		app := NewApplication()
+		app.SetLogger(mckLogger)
+		app.SetMetrics(mckStat)
 
-	mckRouter := NewMockRouter(mockCtrl)
-	app.SetRouter(mckRouter)
+		eh := NewEndpointHandler()
+		eh.setApp(app)
+		eh.maxDataLen = 512
+		app.SetEndpointHandler(eh)
 
-	srv := new(Serv)
-	srv.Init(app, srv.ConfigStruct())
-	app.SetServer(srv)
+		Convey("Should require PUT requests", func() {
+			resp := httptest.NewRecorder()
+			req := &http.Request{
+				Method: "POST",
+				Header: http.Header{},
+				URL:    &url.URL{Path: "/update/123"},
+			}
+			mckStat.EXPECT().Increment("updates.appserver.invalid")
+			eh.ServeMux().ServeHTTP(resp, req)
 
-	eh := NewEndpointHandler()
-	ehConf := eh.ConfigStruct().(*EndpointHandlerConfig)
-	ehConf.AlwaysRoute = true
-	ehConf.Listener.Addr = ""
-	eh.Init(app, ehConf)
-	app.SetEndpointHandler(eh)
+			So(resp.Code, ShouldEqual, 405)
+			body, isJSON := getJSON(resp.HeaderMap, resp.Body)
+			So(isJSON, ShouldBeTrue)
+			So(body.String(), ShouldEqual, `"Method Not Allowed"`)
+		})
 
-	Convey("Should route messages if the device is not connected", t, func() {
-		// ...
+		Convey("Should reject negative versions", func() {
+			vals := make(url.Values)
+			vals.Set("version", "-1")
+
+			resp := httptest.NewRecorder()
+			req := &http.Request{
+				Method: "PUT",
+				Header: http.Header{},
+				URL:    &url.URL{Path: "/update/123"},
+				Body:   formReader(vals),
+			}
+			mckStat.EXPECT().Increment("updates.appserver.invalid")
+			eh.ServeMux().ServeHTTP(resp, req)
+
+			So(resp.Code, ShouldEqual, 400)
+			body, isJSON := getJSON(resp.HeaderMap, resp.Body)
+			So(isJSON, ShouldBeTrue)
+			So(body.String(), ShouldEqual, `"Invalid Version"`)
+		})
+
+		Convey("Should reject invalid versions", func() {
+			vals := make(url.Values)
+			vals.Set("version", "abc")
+
+			resp := httptest.NewRecorder()
+			req := &http.Request{
+				Method: "PUT",
+				Header: http.Header{},
+				URL:    &url.URL{Path: "/update/123"},
+				Body:   formReader(vals),
+			}
+			mckStat.EXPECT().Increment("updates.appserver.invalid")
+			eh.ServeMux().ServeHTTP(resp, req)
+
+			So(resp.Code, ShouldEqual, 400)
+			body, isJSON := getJSON(resp.HeaderMap, resp.Body)
+			So(isJSON, ShouldBeTrue)
+			So(body.String(), ShouldEqual, `"Invalid Version"`)
+		})
+
+		Convey("Should reject oversized payloads", func() {
+			vals := make(url.Values)
+			vals.Set("data", randomText(1024))
+
+			resp := httptest.NewRecorder()
+			req := &http.Request{
+				Method: "PUT",
+				Header: http.Header{},
+				URL:    &url.URL{Path: "/update/123"},
+				Body:   formReader(vals),
+			}
+
+			mckStat.EXPECT().Increment("updates.appserver.toolong")
+			eh.ServeMux().ServeHTTP(resp, req)
+
+			So(resp.Code, ShouldEqual, 413)
+			body, isJSON := getJSON(resp.HeaderMap, resp.Body)
+			So(isJSON, ShouldBeTrue)
+			So(body.String(), ShouldEqual, `"Data exceeds max length of 512 bytes"`)
+		})
 	})
+}
 
-	Convey("Should route messages if `AlwaysRoute` is enabled", t, func() {
-		uaid := "6952a68e-e0e7-444e-bc54-f935c4444b13"
-		mockWorker := NewMockWorker(mockCtrl)
-		pws := &PushWS{}
-		client := &Client{mockWorker, pws, uaid}
-		app.AddClient(uaid, client)
+func TestEndpointPinger(t *testing.T) {
+	useMockFuncs()
+	defer useStdFuncs()
 
-		chid := "b7ede546-585f-4cc9-b95e-9340e3406951"
-		logID := "debc7e71-a6ac-4d17-8729-79999c7034f6"
-		version := int64(1)
-		data := "Happy, happy, joy, joy!"
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
 
-		mckStat.EXPECT().Increment("updates.routed.outgoing").Times(1)
-		mckRouter.EXPECT().Route(nil, uaid, chid, version, gomock.Any(), logID, data).Return(false, nil).Times(1)
-		mockWorker.EXPECT().Flush(pws, int64(0), chid, version, data).Return(nil).Times(1)
-		mckStat.EXPECT().Increment("updates.appserver.received").Times(1)
+	mckLogger := NewMockLogger(mockCtrl)
+	mckLogger.EXPECT().ShouldLog(gomock.Any()).Return(true).AnyTimes()
+	mckLogger.EXPECT().Log(gomock.Any(), gomock.Any(),
+		gomock.Any(), gomock.Any()).AnyTimes()
 
-		ok := eh.deliver(nil, uaid, chid, version, logID, data)
-		So(ok, ShouldBeTrue)
+	mckStat := NewMockStatistician(mockCtrl)
+	mckPinger := NewMockPropPinger(mockCtrl)
+	mckStore := NewMockStore(mockCtrl)
+	mckServ := NewMockServer(mockCtrl)
+	mckWorker := NewMockWorker(mockCtrl)
+
+	Convey("Proprietary pings", t, func() {
+		app := NewApplication()
+		app.SetLogger(mckLogger)
+		app.SetMetrics(mckStat)
+		app.SetPropPinger(mckPinger)
+		app.SetStore(mckStore)
+		app.SetServer(mckServ)
+
+		eh := NewEndpointHandler()
+		eh.setApp(app)
+		eh.maxDataLen = 4096
+		app.SetEndpointHandler(eh)
+
+		Convey("Should return early if the pinger can bypass the WebSocket", func() {
+			uaid := "91357e1a34714cadacb3f13cf47a2736"
+			client := &Client{Worker: mckWorker, UAID: uaid}
+			app.AddClient(uaid, client)
+
+			resp := httptest.NewRecorder()
+			req := &http.Request{
+				Method: "PUT",
+				Header: http.Header{},
+				URL:    &url.URL{Path: "/update/123"},
+				Body:   nil,
+			}
+			gomock.InOrder(
+				mckStore.EXPECT().KeyToIDs("123").Return(uaid, "456", true),
+				mckStat.EXPECT().Increment("updates.appserver.incoming"),
+				mckPinger.EXPECT().Send(uaid, int64(1257894000), "").Return(true, nil),
+				mckPinger.EXPECT().CanBypassWebsocket().Return(true),
+				mckStat.EXPECT().Increment("updates.appserver.received"),
+				mckStat.EXPECT().Timer("updates.handled", gomock.Any()),
+			)
+			eh.ServeMux().ServeHTTP(resp, req)
+
+			So(resp.Code, ShouldEqual, 200)
+			body, isJSON := getJSON(resp.HeaderMap, resp.Body)
+			So(isJSON, ShouldBeTrue)
+			So(body.String(), ShouldEqual, "{}")
+		})
+
+		Convey("Should continue if the pinger cannot bypass the WebSocket", func() {
+			uaid := "e3fc2cf1dc44424685010148b076d08b"
+			client := &Client{Worker: mckWorker, UAID: uaid}
+			app.AddClient(uaid, client)
+
+			data := randomText(eh.maxDataLen)
+			vals := make(url.Values)
+			vals.Set("data", data)
+
+			resp := httptest.NewRecorder()
+			req := &http.Request{
+				Method: "PUT",
+				Header: http.Header{},
+				URL:    &url.URL{Path: "/update/123"},
+				Body:   formReader(vals),
+			}
+			gomock.InOrder(
+				mckStore.EXPECT().KeyToIDs("123").Return(uaid, "456", true),
+				mckStat.EXPECT().Increment("updates.appserver.incoming"),
+				mckPinger.EXPECT().Send(uaid, int64(1257894000), data).Return(true, nil),
+				mckPinger.EXPECT().CanBypassWebsocket().Return(false),
+				mckStore.EXPECT().Update(uaid, "456", int64(1257894000)),
+				mckServ.EXPECT().RequestFlush(client, "456", int64(1257894000), data),
+				mckStat.EXPECT().Increment("updates.appserver.received"),
+				mckStat.EXPECT().Timer("updates.handled", gomock.Any()),
+			)
+			eh.ServeMux().ServeHTTP(resp, req)
+
+			So(resp.Code, ShouldEqual, 200)
+			body, isJSON := getJSON(resp.HeaderMap, resp.Body)
+			So(isJSON, ShouldBeTrue)
+			So(body.String(), ShouldEqual, "{}")
+		})
+
+		Convey("Should continue if the pinger fails", func() {
+			uaid := "8f412f5cb2384183bf60f7da26737271"
+			client := &Client{Worker: mckWorker, UAID: uaid}
+			app.AddClient(uaid, client)
+
+			vals := make(url.Values)
+			vals.Set("version", "7")
+			resp := httptest.NewRecorder()
+			req := &http.Request{
+				Method: "PUT",
+				Header: http.Header{},
+				URL:    &url.URL{Path: "/update/123"},
+				Body:   formReader(vals),
+			}
+			gomock.InOrder(
+				mckStore.EXPECT().KeyToIDs("123").Return(uaid, "456", true),
+				mckStat.EXPECT().Increment("updates.appserver.incoming"),
+				mckPinger.EXPECT().Send(uaid, int64(7), "").Return(
+					true, errors.New("oops")),
+				mckStore.EXPECT().Update(uaid, "456", int64(7)),
+				mckServ.EXPECT().RequestFlush(client, "456", int64(7), ""),
+				mckStat.EXPECT().Increment("updates.appserver.received"),
+				mckStat.EXPECT().Timer("updates.handled", gomock.Any()),
+			)
+			eh.ServeMux().ServeHTTP(resp, req)
+
+			So(resp.Code, ShouldEqual, 200)
+			body, isJSON := getJSON(resp.HeaderMap, resp.Body)
+			So(isJSON, ShouldBeTrue)
+			So(body.String(), ShouldEqual, "{}")
+		})
+	})
+}
+
+func TestEndpointDelivery(t *testing.T) {
+	useMockFuncs()
+	defer useStdFuncs()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mckLogger := NewMockLogger(mockCtrl)
+	mckLogger.EXPECT().ShouldLog(gomock.Any()).Return(true).AnyTimes()
+	mckLogger.EXPECT().Log(gomock.Any(), gomock.Any(),
+		gomock.Any(), gomock.Any()).AnyTimes()
+
+	mckStat := NewMockStatistician(mockCtrl)
+	mckStore := NewMockStore(mockCtrl)
+	mckRouter := NewMockRouter(mockCtrl)
+	mckServ := NewMockServer(mockCtrl)
+
+	Convey("Update delivery", t, func() {
+		app := NewApplication()
+		app.SetLogger(mckLogger)
+		app.SetMetrics(mckStat)
+		app.SetStore(mckStore)
+		app.SetRouter(mckRouter)
+		app.SetServer(mckServ)
+
+		Convey("Should attempt local delivery if `AlwaysRoute` is disabled", func() {
+			eh := NewEndpointHandler()
+			eh.setApp(app)
+			app.SetEndpointHandler(eh)
+
+			Convey("Should route updates if the device is not connected", func() {
+				uaid := "f7e9fc483f7344c398701b6fa0e85e4f"
+				chid := "737b7a0d25674be4bb184f015fce02cf"
+				gomock.InOrder(
+					mckStat.EXPECT().Increment("updates.routed.outgoing"),
+					mckRouter.EXPECT().Route(nil, uaid, chid, int64(3), timeNow().UTC(),
+						"", "").Return(true, nil),
+				)
+				ok := eh.deliver(nil, uaid, chid, 3, "", "")
+				So(ok, ShouldBeTrue)
+			})
+
+			Convey("Should return a 404 if routing fails", func() {
+				resp := httptest.NewRecorder()
+				req := &http.Request{
+					Method: "PUT",
+					Header: http.Header{HeaderID: {"reqID"}},
+					URL:    &url.URL{Path: "/update/123"},
+					Body:   formReader(url.Values{"version": {"1"}}),
+				}
+				gomock.InOrder(
+					mckStore.EXPECT().KeyToIDs("123").Return("123", "456", true),
+					mckStat.EXPECT().Increment("updates.appserver.incoming"),
+					mckStore.EXPECT().Update("123", "456", int64(1)).Return(nil),
+					mckStat.EXPECT().Increment("updates.routed.outgoing"),
+					mckRouter.EXPECT().Route(nil, "123", "456", int64(1),
+						gomock.Any(), "reqID", "").Return(false, nil),
+				)
+				eh.ServeMux().ServeHTTP(resp, req)
+
+				So(resp.Code, ShouldEqual, 404)
+				body, isJSON := getJSON(resp.HeaderMap, resp.Body)
+				So(isJSON, ShouldBeTrue)
+				So(body.String(), ShouldEqual, "false")
+			})
+
+			Convey("Should return a 404 if local delivery fails", func() {
+				uaid := "9e98d6415d8e4fd099ab1bad7178f750"
+				chid := "0eecf572e99f4d508666d8da6c0b15a9"
+				client := &Client{}
+				app.AddClient(uaid, client)
+
+				gomock.InOrder(
+					mckServ.EXPECT().RequestFlush(client, chid, int64(3), "").Return(
+						errors.New("client gone")),
+					mckStat.EXPECT().Increment("updates.appserver.rejected"),
+				)
+				ok := eh.deliver(nil, uaid, chid, int64(3), "", "")
+				So(ok, ShouldBeFalse)
+			})
+
+			Convey("Should return an error if storage is unavailable", func() {
+				resp := httptest.NewRecorder()
+				req := &http.Request{
+					Method: "PUT",
+					Header: http.Header{},
+					URL:    &url.URL{Path: "/update/123"},
+					Body:   formReader(url.Values{"version": {"2"}}),
+				}
+				updateErr := ErrInvalidChannel
+				gomock.InOrder(
+					mckStore.EXPECT().KeyToIDs("123").Return("123", "456", true),
+					mckStat.EXPECT().Increment("updates.appserver.incoming"),
+					mckStore.EXPECT().Update("123", "456", int64(2)).Return(updateErr),
+					mckStat.EXPECT().Increment("updates.appserver.error"),
+				)
+				eh.ServeMux().ServeHTTP(resp, req)
+
+				So(resp.Code, ShouldEqual, updateErr.Status())
+				body, isJSON := getJSON(resp.HeaderMap, resp.Body)
+				So(isJSON, ShouldBeTrue)
+				So(body.String(), ShouldEqual, `"Could not update channel version"`)
+			})
+		})
+
+		Convey("Should always route updates if `AlwaysRoute` is enabled", func() {
+			eh := NewEndpointHandler()
+			eh.setApp(app)
+			eh.alwaysRoute = true
+			app.SetEndpointHandler(eh)
+
+			uaid := "6952a68ee0e7444ebc54f935c4444b13"
+			client := &Client{}
+			app.AddClient(uaid, client)
+
+			chid := "b7ede546585f4cc9b95e9340e3406951"
+			version := int64(1)
+			data := "Happy, happy, joy, joy!"
+
+			gomock.InOrder(
+				mckStat.EXPECT().Increment("updates.routed.outgoing"),
+				mckRouter.EXPECT().Route(nil, uaid, chid, version,
+					gomock.Any(), "", data).Return(false, nil),
+				mckServ.EXPECT().RequestFlush(client, chid, version, data).Return(nil),
+				mckStat.EXPECT().Increment("updates.appserver.received"),
+			)
+
+			ok := eh.deliver(nil, uaid, chid, version, "", data)
+			So(ok, ShouldBeTrue)
+		})
 	})
 }

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint_test.go
@@ -190,7 +190,7 @@ func TestEndpointContentType(t *testing.T) {
 		app := NewApplication()
 		eh := NewEndpointHandler()
 		eh.setApp(app)
-		eh.maxDataLen = 4096
+		eh.setMaxDataLen(4096)
 		app.SetEndpointHandler(eh)
 
 		Convey("Should supply a content type if omitted", func() {
@@ -263,7 +263,7 @@ func TestEndpointInvalidParams(t *testing.T) {
 
 		eh := NewEndpointHandler()
 		eh.setApp(app)
-		eh.maxDataLen = 512
+		eh.setMaxDataLen(512)
 		app.SetEndpointHandler(eh)
 
 		Convey("Should require PUT requests", func() {
@@ -324,7 +324,7 @@ func TestEndpointInvalidParams(t *testing.T) {
 
 		Convey("Should reject oversized payloads", func() {
 			vals := make(url.Values)
-			vals.Set("data", randomText(1024))
+			vals.Set("data", randomText(eh.maxDataLen+1))
 
 			resp := httptest.NewRecorder()
 			req := &http.Request{
@@ -373,7 +373,7 @@ func TestEndpointPinger(t *testing.T) {
 
 		eh := NewEndpointHandler()
 		eh.setApp(app)
-		eh.maxDataLen = 4096
+		eh.setMaxDataLen(4096)
 		app.SetEndpointHandler(eh)
 
 		Convey("Should return early if the pinger can bypass the WebSocket", func() {

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint_test.go
@@ -112,7 +112,7 @@ func TestEndpointResolveKey(t *testing.T) {
 			So(body.String(), ShouldEqual, `"Invalid Token"`)
 		})
 
-		Convey("Should not decode plaintext tokens", func() {
+		Convey("Should not decode plaintext tokens without a key", func() {
 			var err error
 
 			app.SetTokenKey("")
@@ -166,6 +166,10 @@ func TestEndpointResolveKey(t *testing.T) {
 			So(err, ShouldNotBeNil)
 
 			_, _, err = eh.resolvePK(invalidKey)
+			So(err, ShouldNotBeNil)
+
+			// Reject plaintext tokens if a key is specified.
+			_, _, err = eh.resolvePK(validKey)
 			So(err, ShouldNotBeNil)
 
 			mckStore.EXPECT().KeyToIDs(validKey).Return("", "", false)

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint_test.go
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package simplepush
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rafrombrc/gomock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestDeliver(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	app := NewApplication()
+	app.hostname = "test"
+	app.clientMinPing = 10 * time.Second
+	app.clientHelloTimeout = 10 * time.Second
+	app.pushLongPongs = true
+
+	mckLogger := NewMockLogger(mockCtrl)
+	mckLogger.EXPECT().ShouldLog(gomock.Any()).Return(true).AnyTimes()
+	mckLogger.EXPECT().Log(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	app.SetLogger(mckLogger)
+
+	mckStat := NewMockStatistician(mockCtrl)
+	mckStat.EXPECT().Gauge("update.client.connections", gomock.Any()).AnyTimes()
+	app.SetMetrics(mckStat)
+
+	mckStore := NewMockStore(mockCtrl)
+	app.SetStore(mckStore)
+
+	mckRouter := NewMockRouter(mockCtrl)
+	app.SetRouter(mckRouter)
+
+	srv := new(Serv)
+	srv.Init(app, srv.ConfigStruct())
+	app.SetServer(srv)
+
+	eh := NewEndpointHandler()
+	ehConf := eh.ConfigStruct().(*EndpointHandlerConfig)
+	ehConf.AlwaysRoute = true
+	ehConf.Listener.Addr = ""
+	eh.Init(app, ehConf)
+	app.SetEndpointHandler(eh)
+
+	Convey("Should route messages if the device is not connected", t, func() {
+		// ...
+	})
+
+	Convey("Should route messages if `AlwaysRoute` is enabled", t, func() {
+		uaid := "6952a68e-e0e7-444e-bc54-f935c4444b13"
+		mockWorker := NewMockWorker(mockCtrl)
+		pws := &PushWS{}
+		client := &Client{mockWorker, pws, uaid}
+		app.AddClient(uaid, client)
+
+		chid := "b7ede546-585f-4cc9-b95e-9340e3406951"
+		logID := "debc7e71-a6ac-4d17-8729-79999c7034f6"
+		version := int64(1)
+		data := "Happy, happy, joy, joy!"
+
+		mckStat.EXPECT().Increment("updates.routed.outgoing").Times(1)
+		mckRouter.EXPECT().Route(nil, uaid, chid, version, gomock.Any(), logID, data).Return(false, nil).Times(1)
+		mockWorker.EXPECT().Flush(pws, int64(0), chid, version, data).Return(nil).Times(1)
+		mckStat.EXPECT().Increment("updates.appserver.received").Times(1)
+
+		ok := eh.deliver(nil, uaid, chid, version, logID, data)
+		So(ok, ShouldBeTrue)
+	})
+}

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_test.go
@@ -55,9 +55,8 @@ func newTestHandler(tb TBLoggingInterface) *Application {
 	return app
 }
 
-var rbuf = make([]byte, 64)
-
-func randomText() string {
+func randomText(size int) string {
+	rbuf := make([]byte, size)
 	rand.Read(rbuf)
 	for i := 0; i < len(rbuf); i++ {
 		rbuf[i] = uint8(rbuf[i])%94 + 32
@@ -91,6 +90,7 @@ func Benchmark_UpdateHandler(b *testing.B) {
 	updateUrl := fmt.Sprintf("http://test/update/%s", key)
 	tmux := app.EndpointHandler().ServeMux()
 	vals := make(url.Values)
+	data := randomText(64)
 	// Begin benchmark:
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -101,7 +101,7 @@ func Benchmark_UpdateHandler(b *testing.B) {
 		}
 		req.Form = vals
 		req.Form.Set("version", strconv.FormatInt(int64(i), 10))
-		req.Form.Set("data", randomText())
+		req.Form.Set("data", data)
 		tmux.ServeHTTP(resp, req)
 		if resp.Body.String() != "{}" {
 			b.Errorf(`Unexpected response from server: "%s"`, resp.Body.String())

--- a/src/github.com/mozilla-services/pushgo/simplepush/mock_router_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/mock_router_test.go
@@ -47,10 +47,11 @@ func (_mr *_MockRouterRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockRouter) Route(cancelSignal <-chan bool, uaid string, chid string, version int64, sentAt time.Time, logID string, data string) error {
+func (_m *MockRouter) Route(cancelSignal <-chan bool, uaid string, chid string, version int64, sentAt time.Time, logID string, data string) (bool, error) {
 	ret := _m.ctrl.Call(_m, "Route", cancelSignal, uaid, chid, version, sentAt, logID, data)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockRouterRecorder) Route(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {

--- a/src/github.com/mozilla-services/pushgo/simplepush/mock_storage_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/mock_storage_test.go
@@ -103,14 +103,14 @@ func (_mr *_MockStoreRecorder) Register(arg0, arg1, arg2 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Register", arg0, arg1, arg2)
 }
 
-func (_m *MockStore) Update(key string, version int64) error {
-	ret := _m.ctrl.Call(_m, "Update", key, version)
+func (_m *MockStore) Update(suaid string, schid string, version int64) error {
+	ret := _m.ctrl.Call(_m, "Update", suaid, schid, version)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockStoreRecorder) Update(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1)
+func (_mr *_MockStoreRecorder) Update(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1, arg2)
 }
 
 func (_m *MockStore) Unregister(suaid string, schid string) error {

--- a/src/github.com/mozilla-services/pushgo/simplepush/no_store.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/no_store.go
@@ -74,7 +74,7 @@ func (n *NoStore) Exists(uaid string) bool {
 }
 
 func (*NoStore) Register(string, string, int64) error                   { return nil }
-func (*NoStore) Update(string, int64) error                             { return nil }
+func (*NoStore) Update(string, string, int64) error                     { return nil }
 func (*NoStore) Unregister(string, string) error                        { return nil }
 func (*NoStore) Drop(string, string) error                              { return nil }
 func (*NoStore) FetchAll(string, time.Time) ([]Update, []string, error) { return nil, nil, nil }

--- a/src/github.com/mozilla-services/pushgo/simplepush/router.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/router.go
@@ -33,7 +33,7 @@ type Router interface {
 
 	// Route a notification
 	Route(cancelSignal <-chan bool, uaid, chid string, version int64,
-		sentAt time.Time, logID string, data string) error
+		sentAt time.Time, logID string, data string) (bool, error)
 
 	// Register handling for a uaid, this func may be called concurrently
 	Register(uaid string) error

--- a/src/github.com/mozilla-services/pushgo/simplepush/router_broadcast_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/router_broadcast_test.go
@@ -98,8 +98,8 @@ func TestBroadcastRouter(t *testing.T) {
 
 		mckLocator.EXPECT().Contacts(gomock.Any()).Return(thisNodeList, nil)
 		mckStat.EXPECT().Increment("updates.routed.incoming")
-		mckStore.EXPECT().IDsToKey(gomock.Any(), gomock.Any()).Return("", true)
-		mckStore.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+		mckStore.EXPECT().Update(gomock.Any(), gomock.Any(),
+			gomock.Any()).Return(nil)
 		mckLogger.EXPECT().ShouldLog(gomock.Any()).Return(true).AnyTimes()
 		mckLogger.EXPECT().Log(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes()
@@ -180,8 +180,8 @@ func BenchmarkRouter(b *testing.B) {
 		mckStat.EXPECT().Increment(gomock.Any()).AnyTimes()
 		mckStat.EXPECT().Gauge(gomock.Any(), gomock.Any()).AnyTimes()
 		mckStat.EXPECT().Timer(gomock.Any(), gomock.Any()).AnyTimes()
-		mckStore.EXPECT().IDsToKey(gomock.Any(), gomock.Any()).Return("", true)
-		mckStore.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+		mckStore.EXPECT().Update(gomock.Any(), gomock.Any(),
+			gomock.Any()).Return(nil)
 		mckLogger.EXPECT().ShouldLog(gomock.Any()).Return(true).AnyTimes()
 		mckLogger.EXPECT().Log(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes()

--- a/src/github.com/mozilla-services/pushgo/simplepush/router_broadcast_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/router_broadcast_test.go
@@ -71,8 +71,9 @@ func TestBroadcastRouter(t *testing.T) {
 		mckStat.EXPECT().Increment("router.dial.error").AnyTimes()
 		mckStat.EXPECT().Increment("router.broadcast.miss").Times(1)
 		mckStat.EXPECT().Timer(gomock.Any(), gomock.Any()).Times(2)
-		err := router.Route(cancelSignal, uaid, chid, version, sentAt, "", "")
+		ok, err := router.Route(cancelSignal, uaid, chid, version, sentAt, "", "")
 		So(err, ShouldBeNil)
+		So(ok, ShouldBeFalse)
 	})
 
 	Convey("Should fail to route if contacts errors", t, func() {
@@ -84,8 +85,9 @@ func TestBroadcastRouter(t *testing.T) {
 		mckStat.EXPECT().Increment("router.dial.success").AnyTimes()
 		mckStat.EXPECT().Increment("router.dial.error").AnyTimes()
 		mckStat.EXPECT().Increment("router.broadcast.error").Times(1)
-		err := router.Route(cancelSignal, uaid, chid, version, sentAt, "", "")
+		ok, err := router.Route(cancelSignal, uaid, chid, version, sentAt, "", "")
 		So(err, ShouldEqual, myErr)
+		So(ok, ShouldBeFalse)
 	})
 
 	Convey("Should succeed self-routing to a valid uaid", t, func() {
@@ -113,8 +115,9 @@ func TestBroadcastRouter(t *testing.T) {
 		mckStat.EXPECT().Timer("updates.routed.hits", gomock.Any())
 		mckStat.EXPECT().Timer("router.handled", gomock.Any())
 
-		err := router.Route(cancelSignal, uaid, chid, version, sentAt, "", "")
+		ok, err := router.Route(cancelSignal, uaid, chid, version, sentAt, "", "")
 		So(err, ShouldBeNil)
+		So(ok, ShouldBeTrue)
 	})
 
 	mckLocator.EXPECT().Close()

--- a/src/github.com/mozilla-services/pushgo/simplepush/server.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/server.go
@@ -262,14 +262,7 @@ func (self *Serv) UpdateClient(client *Client, chid, uid string, vers int64,
 	time time.Time, data string) (err error) {
 
 	var reason string
-	pk, ok := self.store.IDsToKey(uid, chid)
-	if !ok {
-		reason = "Failed to generate PK"
-		err = errors.New("Invalid storage key")
-		goto updateError
-	}
-
-	if err = self.store.Update(pk, vers); err != nil {
+	if err = self.store.Update(uid, chid, vers); err != nil {
 		reason = "Failed to update channel"
 		goto updateError
 	}

--- a/src/github.com/mozilla-services/pushgo/simplepush/storage.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/storage.go
@@ -112,7 +112,7 @@ type Store interface {
 	Register(suaid, schid string, version int64) error
 
 	// Update updates the channel record version.
-	Update(key string, version int64) error
+	Update(suaid, schid string, version int64) error
 
 	// Unregister marks a channel record as inactive.
 	Unregister(suaid, schid string) error


### PR DESCRIPTION
This pull request breaks `UpdateHandler` into separate methods, restores the `AlwaysRoute` option, and adds tests.

* The `always_route` option provides a switch that we can toggle until we have better metrics to determine how many local delivery attempts fail. This is tracked by the `updates.appserver.rejected` counter.
* `Decode` no longer panics with an out-of-bounds error for short, invalid tokens.
* `Router.Route()` now returns `(ok bool, err error)`, where `ok` indicates whether a routed request was accepted by another server.
* The `Store.Update()` signature is now `(uaid, chid string, version int64)`, since all callers already have the decomposed key.

@bbangert, @jrconlin r?