### PR TITLE
Include the EC2 instance ID in `/realstatus`

### DIFF
--- a/src/github.com/mozilla-services/pushgo/simplepush/aws.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/aws.go
@@ -7,6 +7,7 @@ package simplepush
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -54,7 +55,9 @@ func (e *EC2Info) Get(item string) (body string, err error) {
 	if err != nil {
 		return
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		io.Copy(ioutil.Discard, resp.Body)
 		err = fmt.Errorf("Unexpected status code: %d", resp.StatusCode)
 		return
 	}

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_health.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_health.go
@@ -19,6 +19,7 @@ type StatusReport struct {
 	Plugins          []PluginReport `json:"plugins"`
 	Goroutines       int            `json:"goroutines"`
 	Version          string         `json:"version"`
+	LocalHostname    string         `json:"localHostname"`
 }
 
 // TODO: Remove; add a Typ() method to HasConfigStruct.
@@ -49,6 +50,7 @@ type HealthHandlers struct {
 	balancer Balancer
 	sh       Handler
 	eh       Handler
+	info     InstanceInfo
 }
 
 func (h *HealthHandlers) ConfigStruct() interface{} {
@@ -65,6 +67,7 @@ func (h *HealthHandlers) Init(app *Application, _ interface{}) error {
 	h.balancer = app.Balancer()
 	h.sh = app.SocketHandler()
 	h.eh = app.EndpointHandler()
+	h.info = app.InstanceInfo()
 
 	// Register health check handlers with muxes.
 	clientMux := h.sh.ServeMux()
@@ -111,10 +114,12 @@ func (h *HealthHandlers) StatusHandler(resp http.ResponseWriter,
 func (h *HealthHandlers) RealStatusHandler(resp http.ResponseWriter,
 	req *http.Request) {
 
+	lh, _ := h.info.LocalHostname()
 	status := StatusReport{
 		MaxClientConns:   h.sh.MaxConns(),
 		MaxEndpointConns: h.eh.MaxConns(),
 		Version:          VERSION,
+		LocalHostname:    lh,
 	}
 
 	healthy := true

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_health.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_health.go
@@ -19,7 +19,7 @@ type StatusReport struct {
 	Plugins          []PluginReport `json:"plugins"`
 	Goroutines       int            `json:"goroutines"`
 	Version          string         `json:"version"`
-	LocalHostname    string         `json:"localHostname"`
+	InstanceID       string         `json:"instance,omitempty"`
 }
 
 // TODO: Remove; add a Typ() method to HasConfigStruct.
@@ -114,12 +114,12 @@ func (h *HealthHandlers) StatusHandler(resp http.ResponseWriter,
 func (h *HealthHandlers) RealStatusHandler(resp http.ResponseWriter,
 	req *http.Request) {
 
-	lh, _ := h.info.LocalHostname()
+	id, _ := h.info.InstanceID()
 	status := StatusReport{
 		MaxClientConns:   h.sh.MaxConns(),
 		MaxEndpointConns: h.eh.MaxConns(),
 		Version:          VERSION,
-		LocalHostname:    lh,
+		InstanceID:       id,
 	}
 
 	healthy := true


### PR DESCRIPTION
@rpappalax requested an easier way to see the EC2 hostname for SSH access. I think exposing `http://169.254.169.254/latest/meta-data/local-hostname` is safe; AIUI, it's just not meaningful unless you already have access to the Bastion host.

@oremj r?