### PR TITLE
Wait until the locator is ready before accepting client connections

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -235,6 +235,9 @@ type = "static"
 #defaultTTL = "1m"
 # The polling interval for new nodes.
 #refresh_interval = "10s"
+# Time to wait after starting the locator and registering with etcd. Should
+# be 1-2 times the refresh_interval.
+#start_delay = "10s"
 # Time to wait after removing the host from etcd during shutdown. Should
 # be 1-2 times the refresh_interval.
 #close_delay = "20s"

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
@@ -324,7 +324,7 @@ func (h *EndpointHandler) UpdateHandler(resp http.ResponseWriter, req *http.Requ
 
 // deliver routes an incoming update to the appropriate server.
 func (h *EndpointHandler) deliver(cn http.CloseNotifier, uaid, chid string,
-	version int64, requestID string, data string) (ok bool) {
+	version int64, requestID string, data string) (delivered bool) {
 
 	worker, workerConnected := h.app.GetWorker(uaid)
 	// Always route to other servers first, in case we're holding open a stale
@@ -337,9 +337,9 @@ func (h *EndpointHandler) deliver(cn http.CloseNotifier, uaid, chid string,
 			cancelSignal = cn.CloseNotify()
 		}
 		// Route the update.
-		ok, _ = h.router.Route(cancelSignal, uaid, chid, version,
+		delivered, _ = h.router.Route(cancelSignal, uaid, chid, version,
 			timeNow().UTC(), requestID, data)
-		if ok {
+		if delivered {
 			return true
 		}
 	}

--- a/src/github.com/mozilla-services/pushgo/simplepush/locator.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/locator.go
@@ -6,6 +6,15 @@ package simplepush
 
 var AvailableLocators = make(AvailableExtensions)
 
+// ReadyNotifier is an optional interface implemented by Locators that can be
+// used to defer accepting client connections until the Locator has a complete
+// view of the cluster.
+type ReadyNotifier interface {
+	// ReadyNotify returns a channel that is closed when the underlying service
+	// is ready.
+	ReadyNotify() <-chan bool
+}
+
 // Locator describes a contact discovery service.
 type Locator interface {
 	// Close stops and releases any resources associated with the Locator.

--- a/src/github.com/mozilla-services/pushgo/simplepush/locator_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/locator_test.go
@@ -223,10 +223,11 @@ func TestLocatorReadyNotify(t *testing.T) {
 
 	// Initial routing attempt should fail; the WebSocket listener shouldn't
 	// accept client connections before the locator is ready.
-	ok, err := sndApp.Router().Route(nil, uaid, chid, version, timeNow(), "disconnected", data)
+	delivered, err := sndApp.Router().Route(nil, uaid, chid, version, timeNow(),
+		"disconnected", data)
 	if err != nil {
 		t.Errorf("Error routing to disconnected client: %s", err)
-	} else if ok {
+	} else if delivered {
 		t.Error("Should not route to disconnected client")
 	}
 	// Signal the locator is ready, then wait for the client to connect.
@@ -237,10 +238,11 @@ func TestLocatorReadyNotify(t *testing.T) {
 		t.Fatalf("Timed out waiting for the client to connect")
 	}
 	// Routing should succeed once the client is connected.
-	ok, err = sndApp.Router().Route(nil, uaid, chid, version, timeNow(), "connected", data)
+	delivered, err = sndApp.Router().Route(nil, uaid, chid, version, timeNow(),
+		"connected", data)
 	if err != nil {
 		t.Errorf("Error routing to connected client: %s", err)
-	} else if !ok {
+	} else if !delivered {
 		t.Error("Should route to connected client")
 	}
 

--- a/src/github.com/mozilla-services/pushgo/simplepush/locator_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/locator_test.go
@@ -1,0 +1,259 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package simplepush
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rafrombrc/gomock/gomock"
+	"golang.org/x/net/websocket"
+)
+
+// newMockReadyNotifier wraps l in a mockReadyNotifier.
+func newMockReadyNotifier(l Locator) *mockReadyNotifier {
+	return &mockReadyNotifier{Locator: l, readyChan: make(chan bool)}
+}
+
+// mockReadyNotifier implements the Locator and ReadyNotifier interfaces. This
+// is used to test blocking incoming WebSocket connections until the locator is
+// ready.
+type mockReadyNotifier struct {
+	Locator
+	readyChan chan bool
+}
+
+// SignalReady signals that the locator is ready.
+func (m *mockReadyNotifier) SignalReady() { close(m.readyChan) }
+
+// ReadyNotify returns a channel that is closed by SignalReady.
+func (m *mockReadyNotifier) ReadyNotify() <-chan bool { return m.readyChan }
+
+func TestLocatorReadyNotify(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	uaid := "fce61180716a40ed8e79bf5ff0ba34bc"
+
+	mckLogger := NewMockLogger(mockCtrl)
+	mckLogger.EXPECT().ShouldLog(gomock.Any()).Return(true).AnyTimes()
+	mckLogger.EXPECT().Log(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any()).AnyTimes()
+
+	var (
+		// routerPipes maps fake peer addresses to their respective pipes. Used
+		// by dialRouter to connect to peers.
+		routerPipes = make(map[netAddr]*pipeListener)
+
+		// contacts is a list of peer URLs for the locator.
+		contacts []string
+	)
+
+	// Fake listener for the sender's router, used to test self-routing.
+	sndRouterAddr := netAddr{"tcp", "snd-router.example.com:3000"}
+	sndRouterPipe := newPipeListener()
+	defer sndRouterPipe.Close()
+	routerPipes[sndRouterAddr] = sndRouterPipe
+	contacts = append(contacts, "http://snd-router.example.com:3000")
+
+	// Fake listener for the receiver's router, used to test routing updates
+	// to different hosts.
+	recvRouterAddr := netAddr{"tcp", "recv-router.example.com:3000"}
+	recvRouterPipe := newPipeListener()
+	defer recvRouterPipe.Close()
+	routerPipes[recvRouterAddr] = recvRouterPipe
+	contacts = append(contacts, "http://recv-router.example.com:3000")
+
+	// Fake listener for the receiver's WebSocket handler, used to accept a
+	// WebSocket client connection.
+	socketHandlerPipe := newPipeListener()
+	defer socketHandlerPipe.Close()
+
+	// Fake locator.
+	mckLocator := NewMockLocator(mockCtrl)
+	mckLocator.EXPECT().Contacts(uaid).Return(contacts, nil).Times(2)
+
+	// Fake dialer to connect to each peer's routing listener.
+	dialRouter := func(network, address string) (net.Conn, error) {
+		if pipe, ok := routerPipes[netAddr{network, address}]; ok {
+			return pipe.Dial(network, address)
+		}
+		return nil, &netErr{temporary: false, timeout: false}
+	}
+	// Configures a fake router for the app.
+	setRouter := func(app *Application, listener net.Listener) {
+		r := NewBroadcastRouter()
+		r.setApp(app)
+		r.setClientOptions(10, 3*time.Second, 3*time.Second) // Defaults.
+		r.setClientTransport(&http.Transport{Dial: dialRouter})
+		r.listenWithConfig(listenerConfig{listener: listener})
+		r.maxDataLen = 4096
+		r.server = newServeWaiter(&http.Server{Handler: r.ServeMux()})
+		app.SetRouter(r)
+	}
+
+	// sndApp is the server broadcasting the update. The locator returns the
+	// addresses of the sender and receiver to test self-routing.
+	sndApp := NewApplication()
+	sndApp.SetLogger(mckLogger)
+	sndStat := NewMockStatistician(mockCtrl)
+	sndApp.SetMetrics(sndStat)
+	sndApp.SetLocator(mckLocator)
+	// Set up a fake router for the sender.
+	setRouter(sndApp, sndRouterPipe)
+
+	// recvApp is the server receiving the update.
+	recvApp := NewApplication()
+	recvApp.SetLogger(mckLogger)
+	recvStat := NewMockStatistician(mockCtrl)
+	recvApp.SetMetrics(recvStat)
+	recvStore := NewMockStore(mockCtrl)
+	recvApp.SetStore(recvStore)
+	// Wrap the fake locator in a type that implements ReadyNotifier.
+	recvLocator := newMockReadyNotifier(mckLocator)
+	recvApp.SetLocator(recvLocator)
+	// Set up a fake WebSocket handler for the receiver.
+	recvSocketHandler := NewSocketHandler()
+	recvSocketHandler.setApp(recvApp)
+	recvSocketHandler.listenWithConfig(listenerConfig{
+		listener: socketHandlerPipe})
+	recvSocketHandler.server = newServeWaiter(&http.Server{Handler: recvSocketHandler.ServeMux()})
+	recvApp.SetSocketHandler(recvSocketHandler)
+	// Set up a fake router for the receiver.
+	setRouter(recvApp, recvRouterPipe)
+
+	chid := "2b7c5c27d6224bfeaf1c158c3c57fca3"
+	version := int64(2)
+	data := "I'm a little teapot, short and stout."
+
+	var wg sync.WaitGroup // Waits for the client to close.
+	wg.Add(1)
+	dialChan := make(chan bool) // Signals when the client connects.
+	timeout := closeAfter(2 * time.Second)
+
+	go func() {
+		defer wg.Done()
+		origin := &url.URL{Scheme: "ws", Host: "recv-conn.example.com"}
+		ws, err := dialSocketListener(socketHandlerPipe, &websocket.Config{
+			Location: origin,
+			Origin:   origin,
+			Version:  websocket.ProtocolVersionHybi13,
+		})
+		if err != nil {
+			t.Errorf("Error dialing host: %s", err)
+			return
+		}
+		defer ws.Close()
+		err = websocket.JSON.Send(ws, struct {
+			Type       string   `json:"messageType"`
+			DeviceID   string   `json:"uaid"`
+			ChannelIDs []string `json:"channelIDs"`
+		}{"hello", uaid, []string{}})
+		if err != nil {
+			t.Errorf("Error writing handshake request: %s", err)
+			return
+		}
+		helloReply := new(HelloReply)
+		if err = websocket.JSON.Receive(ws, helloReply); err != nil {
+			t.Errorf("Error reading handshake reply: %s", err)
+			return
+		}
+		select {
+		case dialChan <- true:
+		case <-timeout:
+			t.Errorf("Timed out waiting for router")
+			return
+		}
+		flushReply := new(FlushReply)
+		if err = websocket.JSON.Receive(ws, flushReply); err != nil {
+			t.Errorf("Error reading routed update: %s", err)
+			return
+		}
+		ok := false
+		expected := Update{chid, uint64(version), data}
+		for _, update := range flushReply.Updates {
+			if ok = update == expected; ok {
+				break
+			}
+		}
+		if !ok {
+			t.Errorf("Missing update %#v in %#v", expected, flushReply.Updates)
+			return
+		}
+	}()
+
+	// Start the handlers.
+	errChan := make(chan error, 3)
+	go sndApp.Router().Start(errChan)
+	go recvApp.SocketHandler().Start(errChan)
+	go recvApp.Router().Start(errChan)
+
+	// First and second routing attempts to self.
+	sndStat.EXPECT().Increment("updates.routed.unknown").Times(2)
+	// First routing attempt to peer.
+	sndStat.EXPECT().Increment("router.broadcast.miss")
+	sndStat.EXPECT().Timer("updates.routed.misses", gomock.Any())
+	sndStat.EXPECT().Timer("router.handled", gomock.Any())
+	// Second routing attempt to peer.
+	sndStat.EXPECT().Increment("router.broadcast.hit")
+	sndStat.EXPECT().Timer("updates.routed.hits", gomock.Any())
+	sndStat.EXPECT().Timer("router.handled", gomock.Any())
+
+	// Initial routing attempt to peer.
+	recvStat.EXPECT().Increment("updates.routed.unknown")
+	// Client connects to peer.
+	recvStat.EXPECT().Increment("client.socket.connect")
+	recvStore.EXPECT().CanStore(0).Return(true)
+	recvStat.EXPECT().Increment("updates.client.hello")
+	recvStore.EXPECT().FetchAll(uaid, gomock.Any()).Return(nil, nil, nil)
+	recvStat.EXPECT().Timer("client.flush", gomock.Any())
+	// Second routing attempt to peer.
+	recvStat.EXPECT().Increment("updates.routed.incoming")
+	recvStat.EXPECT().Increment("updates.sent")
+	recvStat.EXPECT().Timer("client.flush", gomock.Any())
+	recvStat.EXPECT().Increment("updates.routed.received")
+	recvStat.EXPECT().Timer("client.socket.lifespan", gomock.Any())
+	recvStat.EXPECT().Increment("client.socket.disconnect")
+
+	// Initial routing attempt should fail; the WebSocket listener shouldn't
+	// accept client connections before the locator is ready.
+	ok, err := sndApp.Router().Route(nil, uaid, chid, version, timeNow(), "disconnected", data)
+	if err != nil {
+		t.Errorf("Error routing to disconnected client: %s", err)
+	} else if ok {
+		t.Error("Should not route to disconnected client")
+	}
+	// Signal the locator is ready, then wait for the client to connect.
+	recvLocator.SignalReady()
+	select {
+	case <-dialChan:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Timed out waiting for the client to connect")
+	}
+	// Routing should succeed once the client is connected.
+	ok, err = sndApp.Router().Route(nil, uaid, chid, version, timeNow(), "connected", data)
+	if err != nil {
+		t.Errorf("Error routing to connected client: %s", err)
+	} else if !ok {
+		t.Error("Should route to connected client")
+	}
+
+	mckLocator.EXPECT().Close().Times(2)
+	if err := recvApp.Close(); err != nil {
+		t.Errorf("Error closing peer: %s", err)
+	}
+	wg.Wait()
+	if err := sndApp.Close(); err != nil {
+		t.Errorf("Error closing self: %s", err)
+	}
+	// Wait for the handlers to stop.
+	for i := 0; i < 3; i++ {
+		<-errChan
+	}
+}

--- a/src/github.com/mozilla-services/pushgo/simplepush/mock_locator_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/mock_locator_test.go
@@ -7,6 +7,37 @@ import (
 	gomock "github.com/rafrombrc/gomock/gomock"
 )
 
+// Mock of ReadyNotifier interface
+type MockReadyNotifier struct {
+	ctrl     *gomock.Controller
+	recorder *_MockReadyNotifierRecorder
+}
+
+// Recorder for MockReadyNotifier (not exported)
+type _MockReadyNotifierRecorder struct {
+	mock *MockReadyNotifier
+}
+
+func NewMockReadyNotifier(ctrl *gomock.Controller) *MockReadyNotifier {
+	mock := &MockReadyNotifier{ctrl: ctrl}
+	mock.recorder = &_MockReadyNotifierRecorder{mock}
+	return mock
+}
+
+func (_m *MockReadyNotifier) EXPECT() *_MockReadyNotifierRecorder {
+	return _m.recorder
+}
+
+func (_m *MockReadyNotifier) ReadyNotify() <-chan bool {
+	ret := _m.ctrl.Call(_m, "ReadyNotify")
+	ret0, _ := ret[0].(<-chan bool)
+	return ret0
+}
+
+func (_mr *_MockReadyNotifierRecorder) ReadyNotify() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReadyNotify")
+}
+
 // Mock of Locator interface
 type MockLocator struct {
 	ctrl     *gomock.Controller

--- a/src/github.com/mozilla-services/pushgo/simplepush/net.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/net.go
@@ -124,7 +124,9 @@ func (c *limitConn) Close() error {
 	return err
 }
 
-// isTerminalState indicates whether state is a terminal connection state.
+// isTerminalState indicates whether state is the last connection state for
+// which the http.Server.ConnState hook will be called. This is used by
+// ServeCloser to remove tracked connections from its map.
 func isTerminalState(state http.ConnState) bool {
 	return state == http.StateClosed || state == http.StateHijacked
 }
@@ -160,6 +162,8 @@ func (s *ServeCloser) Close() error {
 }
 
 func (s *ServeCloser) close() error {
+	// Disable HTTP keep-alive for requests handled before the underlying
+	// connections are closed.
 	s.SetKeepAlivesEnabled(false)
 	s.connsLock.Lock()
 	defer s.connsLock.Unlock()

--- a/src/github.com/mozilla-services/pushgo/simplepush/router_broadcast_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/router_broadcast_test.go
@@ -71,9 +71,10 @@ func TestBroadcastRouter(t *testing.T) {
 		mckStat.EXPECT().Increment("router.dial.error").AnyTimes()
 		mckStat.EXPECT().Increment("router.broadcast.miss").Times(1)
 		mckStat.EXPECT().Timer(gomock.Any(), gomock.Any()).Times(2)
-		ok, err := router.Route(cancelSignal, uaid, chid, version, sentAt, "", "")
+		delivered, err := router.Route(cancelSignal, uaid, chid, version, sentAt,
+			"", "")
 		So(err, ShouldBeNil)
-		So(ok, ShouldBeFalse)
+		So(delivered, ShouldBeFalse)
 	})
 
 	Convey("Should fail to route if contacts errors", t, func() {
@@ -85,9 +86,10 @@ func TestBroadcastRouter(t *testing.T) {
 		mckStat.EXPECT().Increment("router.dial.success").AnyTimes()
 		mckStat.EXPECT().Increment("router.dial.error").AnyTimes()
 		mckStat.EXPECT().Increment("router.broadcast.error").Times(1)
-		ok, err := router.Route(cancelSignal, uaid, chid, version, sentAt, "", "")
+		delivered, err := router.Route(cancelSignal, uaid, chid, version, sentAt,
+			"", "")
 		So(err, ShouldEqual, myErr)
-		So(ok, ShouldBeFalse)
+		So(delivered, ShouldBeFalse)
 	})
 
 	Convey("Should succeed self-routing to a valid uaid", t, func() {
@@ -111,9 +113,10 @@ func TestBroadcastRouter(t *testing.T) {
 		mckStat.EXPECT().Timer("updates.routed.hits", gomock.Any())
 		mckStat.EXPECT().Timer("router.handled", gomock.Any())
 
-		ok, err := router.Route(cancelSignal, uaid, chid, version, sentAt, "", "")
+		delivered, err := router.Route(cancelSignal, uaid, chid, version, sentAt,
+			"", "")
 		So(err, ShouldBeNil)
-		So(ok, ShouldBeTrue)
+		So(delivered, ShouldBeTrue)
 	})
 
 	router.Close()

--- a/src/github.com/mozilla-services/pushgo/simplepush/router_broadcast_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/router_broadcast_test.go
@@ -116,7 +116,6 @@ func TestBroadcastRouter(t *testing.T) {
 		So(ok, ShouldBeTrue)
 	})
 
-	mckLocator.EXPECT().Close()
 	router.Close()
 	<-errChan
 }


### PR DESCRIPTION
This pull request adds an optional `ReadyNotifier` interface that locators can use to defer accepting client connections. Closes #111.