### PR TITLE
Make environment variables match TOML field names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 script:
 - make test
 - make travis-cov
-- PUSHGO_TEST_STORAGE_MC_HOSTS=localhost:11211 make test-gomemcache
+- PUSHGO_TEST_STORAGE_MEMCACHE_SERVER=localhost:11211 make test-gomemcache
 before_deploy:
 - sudo apt-get -qq remove -y libmemcached-dev
 - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ utopic main"

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,6 @@ EXPOSE 8081
 # Internal routing port; should not be published.
 EXPOSE 3000
 
-ENV PUSHGO_METRICS_STATSD_HOST :8125
+ENV PUSHGO_METRICS_STATSD_SERVER :8125
 
 ENTRYPOINT ["./simplepush", "-config=config.docker.toml"]

--- a/setup_test_server.rst
+++ b/setup_test_server.rst
@@ -118,7 +118,7 @@ Copy/Paste the following into your ssh session to the instance, these instructio
     STATSD_IP=$(docker inspect $STATSD_CID | grep IPAddress | cut -d '"' -f 4)
 
     docker run -d --volume=/var/log:/var/log:rw \
-        -e PUSHGO_METRICS_STATSD_HOST=$STATSD_IP:8125 \
+        -e PUSHGO_METRICS_STATSD_SERVER=$STATSD_IP:8125 \
         -e PUSHGO_DEFAULT_RESOLVE_HOST=false \
         -e PUSHGO_DEFAULT_CURRENT_HOST=$PUBLIC_IP \
         -e PUSHGO_ROUTER_DEFAULT_HOST=$PUBLIC_IP \

--- a/src/github.com/mozilla-services/pushgo/simplepush/app.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/app.go
@@ -26,11 +26,11 @@ var (
 type ApplicationConfig struct {
 	Hostname           string `toml:"current_host" env:"current_host"`
 	TokenKey           string `toml:"token_key" env:"token_key"`
-	UseAwsHost         bool   `toml:"use_aws_host" env:"use_aws"`
+	UseAwsHost         bool   `toml:"use_aws_host" env:"use_aws_host"`
 	ResolveHost        bool   `toml:"resolve_host" env:"resolve_host"`
-	ClientMinPing      string `toml:"client_min_ping_interval" env:"min_ping"`
-	ClientHelloTimeout string `toml:"client_hello_timeout" env:"hello_timeout"`
-	PushLongPongs      bool   `toml:"push_long_pongs" env:"long_pongs"`
+	ClientMinPing      string `toml:"client_min_ping_interval" env:"client_min_ping_interval"`
+	ClientHelloTimeout string `toml:"client_hello_timeout" env:"client_hello_timeout"`
+	PushLongPongs      bool   `toml:"push_long_pongs" env:"push_long_pongs"`
 	ClientPongInterval string `toml:"client_pong_interval" env:"client_pong_interval"`
 }
 

--- a/src/github.com/mozilla-services/pushgo/simplepush/config_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/config_test.go
@@ -60,12 +60,12 @@ type = "static"
 
 var env = envconf.New([]string{
 	"PUSHGO_DEFAULT_CURRENT_HOST=push.services.mozilla.com",
-	"pushgo_default_use_aws=0",
+	"pushgo_default_use_aws_host=0",
 	"PushGo_WebSocket_Origins=https://push.services.mozilla.com",
 	"PUSHGO_WEBSOCKET_LISTENER_ADDR=",
-	"PUSHGO_WEBSOCKET_LISTENER_MAX_CONNS=25000",
+	"PUSHGO_WEBSOCKET_LISTENER_MAX_CONNECTIONS=25000",
 	"pushgo_endpoint_listener_addr=",
-	"pushgo_endpoint_listener_max_conns=6000",
+	"pushgo_endpoint_listener_max_connections=6000",
 	"PUSHGO_logging_TYPE=stdout",
 	"pushgo_LOGGING_FORMAT=text",
 	"pushgo_logging_FILTER=0",
@@ -73,7 +73,7 @@ var env = envconf.New([]string{
 	"PUSHGO_PROPPING_URL=http://push.services.mozilla.com/ping",
 	"PushGo_Router_Bucket_Size=15",
 	"PUSHGO_ROUTER_LISTENER_ADDR=",
-	"PUSHGO_ROUTER_LISTENER_MAX_CONNS=12000",
+	"PUSHGO_ROUTER_LISTENER_MAX_CONNECTIONS=12000",
 	"PUSHGO_ENDPOINT_MAX_DATA_LEN=512",
 	"PUSHGO_BALANCER_TYPE=none",
 })

--- a/src/github.com/mozilla-services/pushgo/simplepush/emcee_store.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/emcee_store.go
@@ -65,12 +65,12 @@ func NewEmcee() *EmceeStore {
 // EmceeDriverConf specifies memcached driver options.
 type EmceeDriverConf struct {
 	// Hosts is a list of memcached nodes.
-	Hosts []string `toml:"server"`
+	Hosts []string `toml:"server" env:"server"`
 
 	// MaxConns is the maximum number of open connections managed by the pool.
 	// All returned connections that exceed this limit will be closed. Defaults
 	// to 400.
-	MaxConns int `toml:"max_connections" env:"max_conns"`
+	MaxConns int `toml:"max_connections" env:"max_connections"`
 
 	// RecvTimeout is the socket receive timeout (SO_RCVTIMEO) used by the
 	// memcached driver. Supports microsecond granularity; defaults to 5 seconds.
@@ -116,9 +116,9 @@ type EmceeStore struct {
 
 // EmceeConf specifies memcached adapter options.
 type EmceeConf struct {
-	ElastiCacheConfigEndpoint string          `toml:"elasticache_config_endpoint" env:"elasticache_discovery"`
+	ElastiCacheConfigEndpoint string          `toml:"elasticache_config_endpoint" env:"elasticache_config_endpoint"`
 	MaxChannels               int             `toml:"max_channels" env:"max_channels"`
-	Driver                    EmceeDriverConf `toml:"memcache" env:"mc"`
+	Driver                    EmceeDriverConf `toml:"memcache" env:"memcache"`
 	Db                        DbConf
 }
 

--- a/src/github.com/mozilla-services/pushgo/simplepush/etcd_locator.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/etcd_locator.go
@@ -39,7 +39,7 @@ type EtcdLocatorConf struct {
 
 	// DefaultTTL is the maximum amount of time that registered contacts will be
 	// considered valid. Defaults to "1m".
-	DefaultTTL string `env:"ttl"`
+	DefaultTTL string
 
 	// RefreshInterval is the maximum amount of time that a cached contact list
 	// will be considered valid. Defaults to "10s".

--- a/src/github.com/mozilla-services/pushgo/simplepush/gomemc_store.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/gomemc_store.go
@@ -26,7 +26,7 @@ func NewGomemc() *GomemcStore {
 // GomemcDriverConf specifies memcached driver options.
 type GomemcDriverConf struct {
 	// Hosts is a list of memcached nodes.
-	Hosts []string `toml:"server"`
+	Hosts []string `toml:"server" env:"server"`
 }
 
 // GomemcStore is a memcached adapter.
@@ -45,9 +45,9 @@ type GomemcStore struct {
 
 // GomemcConf specifies memcached adapter options.
 type GomemcConf struct {
-	ElastiCacheConfigEndpoint string           `toml:"elasticache_config_endpoint" env:"elasticache_discovery"`
+	ElastiCacheConfigEndpoint string           `toml:"elasticache_config_endpoint" env:"elasticache_config_endpoint"`
 	MaxChannels               int              `toml:"max_channels" env:"max_channels"`
-	Driver                    GomemcDriverConf `toml:"memcache" env:"mc"`
+	Driver                    GomemcDriverConf `toml:"memcache" env:"memcache"`
 	Db                        DbConf
 }
 

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers.go
@@ -22,10 +22,10 @@ type Handler interface {
 
 type ListenerConfig struct {
 	Addr            string
-	MaxConns        int    `toml:"max_connections" env:"max_conns"`
-	KeepAlivePeriod string `toml:"tcp_keep_alive" env:"keep_alive"`
-	CertFile        string `toml:"cert_file" env:"cert"`
-	KeyFile         string `toml:"key_file" env:"key"`
+	MaxConns        int    `toml:"max_connections" env:"max_connections"`
+	KeepAlivePeriod string `toml:"tcp_keep_alive" env:"tcp_keep_alive"`
+	CertFile        string `toml:"cert_file" env:"cert_file"`
+	KeyFile         string `toml:"key_file" env:"key_file"`
 }
 
 func (conf *ListenerConfig) UseTLS() bool {

--- a/src/github.com/mozilla-services/pushgo/simplepush/metrics.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/metrics.go
@@ -21,9 +21,9 @@ type trec struct {
 type timer map[string]trec
 
 type MetricsConfig struct {
-	StoreSnapshots bool   `toml:"store_snapshots" env:"snapshots"`
+	StoreSnapshots bool   `toml:"store_snapshots" env:"store_snapshots"`
 	Prefix         string `env:"prefix"`
-	StatsdServer   string `toml:"statsd_server" env:"statsd_host"`
+	StatsdServer   string `toml:"statsd_server" env:"statsd_server"`
 	StatsdName     string `toml:"statsd_name" env:"statsd_name"`
 }
 

--- a/src/github.com/mozilla-services/pushgo/simplepush/proprietary_ping.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/proprietary_ping.go
@@ -110,7 +110,7 @@ type UDPPing struct {
 }
 
 type UDPPingConfig struct {
-	URL string `toml:"url" env:"url"` //carrier UDP Proxy URL
+	URL string //carrier UDP Proxy URL
 	// Additional Carrier required elements here.
 }
 

--- a/src/github.com/mozilla-services/pushgo/simplepush/server.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/server.go
@@ -19,7 +19,7 @@ import (
 
 // Basic global server options
 type ServerConfig struct {
-	PushEndpoint string `toml:"push_endpoint_template" env:"push_url_template"`
+	PushEndpoint string `toml:"push_endpoint_template" env:"push_endpoint_template"`
 }
 
 // Server responds to client commands and delivers updates.

--- a/src/github.com/mozilla-services/pushgo/simplepush/static_locator.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/static_locator.go
@@ -5,7 +5,7 @@
 package simplepush
 
 type StaticLocatorConf struct {
-	Contacts []string `env:"contacts"`
+	Contacts []string
 }
 
 type StaticLocator struct {

--- a/src/github.com/mozilla-services/pushgo/simplepush/storage.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/storage.go
@@ -65,16 +65,16 @@ type Update struct {
 // DbConf specifies generic database adapter options.
 type DbConf struct {
 	// TimeoutLive is the active channel record timeout. Defaults to 3 days.
-	TimeoutLive int64 `toml:"timeout_live" env:"live_timeout"`
+	TimeoutLive int64 `toml:"timeout_live" env:"timeout_live"`
 
 	// TimeoutReg is the registered channel record timeout. Defaults to 3 hours;
 	// an app server should send a notification on a registered channel before
 	// this timeout.
-	TimeoutReg int64 `toml:"timeout_reg" env:"reg_timeout"`
+	TimeoutReg int64 `toml:"timeout_reg" env:"timeout_reg"`
 
 	// TimeoutDel is the deleted channel record timeout. Defaults to 1 day;
 	// deleted records will be pruned after this timeout.
-	TimeoutDel int64 `toml:"timeout_del" env:"del_timeout"`
+	TimeoutDel int64 `toml:"timeout_del" env:"timeout_del"`
 
 	// HandleTimeout is the maximum time to wait when acquiring a connection from
 	// the pool. Defaults to 5 seconds.


### PR DESCRIPTION
Dusting off a stale branch...this just makes all `env` tags match their `toml` counterparts. This does mean the current Loads strategy will need to be updated, but hopefully makes it easier to apply overrides without spelunking for the variable name in the source.