### PR TITLE
Add performance profiling handlers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN make simplepush
 EXPOSE 8080
 # HTTP update listener port.
 EXPOSE 8081
+# Profiling port.
+EXPOSE 8082
 
 # Internal routing port; should not be published.
 EXPOSE 3000

--- a/config.docker.toml
+++ b/config.docker.toml
@@ -11,10 +11,6 @@
 #use_aws_host = false
 # Specifies whether the hostname should be resolved to an IP address.
 resolve_host = true
-# A list of allowed WebSocket origins. An empty list allows all origins;
-# otherwise, the scheme, hostname, and port specified in the client's
-# `Origin` header must match at least one allowed origin.
-#origins = []
 
 # This defines what endpoint to use for updates.
 # {{.CurrentHost}} = the current host to connect to.
@@ -40,8 +36,12 @@ resolve_host = true
 client_min_ping_interval = "10s"
 ## Timeout socket if not recv'd hello
 #client_hello_timeout = "30s"
+client_pong_interval = "5m"
 
-[default.websocket]
+[websocket]
+#origins = []
+
+[websocket.listener]
 # The WebSocket listener address and port. 0.0.0.0 = all interfaces
 addr = ":8080"
 # The maximum number of concurrent connections that this listener can
@@ -53,12 +53,22 @@ max_connections = 250000
 #cert_file = "certs/test.crt"
 #key_file = "certs/test.key"
 
+[endpoint]
+#max_data_len = 4096
+
 [default.endpoint]
 addr = ":8081"
 max_connections = 40000
 #tcp_keep_alive = "3m"
 #cert_file = "certs/test.crt"
 #key_file = "certs/test.key"
+
+[profile]
+enable = true
+
+[profile.listener]
+addr = ":8082"
+max_connections = 100
 
 # Proprietary pings
 [propping]
@@ -141,6 +151,8 @@ type = "none"
 # means 16 buckets. Have fun with probability tables to figure out the
 # size that works best for you.)
 #bucket_size = 10
+#max_data_len = 4096
+#idle_conns = 50
 
 [router.listener]
 # Default interface and port for shard routing
@@ -159,6 +171,3 @@ statsd_server = ":8125"
 
 [balancer]
 type = "none"
-
-[handlers]
-max_data_len = 1024

--- a/src/github.com/mozilla-services/pushgo/simplepush/app.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/app.go
@@ -62,8 +62,9 @@ type Application struct {
 	router             Router
 	locator            Locator
 	balancer           Balancer
-	sh                 Handler
-	eh                 Handler
+	sh                 Handler // WebSocket handler.
+	eh                 Handler // HTTP update handler.
+	ph                 Handler // Performance profiling handlers.
 	propping           PropPinger
 	closeChan          chan bool
 	closeOnce          Once
@@ -174,13 +175,19 @@ func (a *Application) SetEndpointHandler(h Handler) error {
 	return nil
 }
 
+func (a *Application) SetProfileHandlers(h Handler) error {
+	a.ph = h
+	return nil
+}
+
 // Start the application
 func (a *Application) Run() (errChan chan error) {
-	errChan = make(chan error, 3)
+	errChan = make(chan error, 4)
 
 	go a.sh.Start(errChan)
 	go a.eh.Start(errChan)
 	go a.router.Start(errChan)
+	go a.ph.Start(errChan)
 
 	go a.sendClientCount()
 	return errChan
@@ -233,6 +240,10 @@ func (a *Application) SocketHandler() Handler {
 
 func (a *Application) EndpointHandler() Handler {
 	return a.eh
+}
+
+func (a *Application) ProfileHandlers() Handler {
+	return a.ph
 }
 
 func (a *Application) TokenKey() []byte {
@@ -334,9 +345,15 @@ func (a *Application) close() error {
 			errors = append(errors, err)
 		}
 	}
-	if a.router != nil {
+	if r := a.Router(); r != nil {
 		// Close the routing listener.
-		if err := a.router.Close(); err != nil {
+		if err := r.Close(); err != nil {
+			errors = append(errors, err)
+		}
+	}
+	if ph := a.ProfileHandlers(); ph != nil {
+		// Stop the profiling listener.
+		if err := ph.Close(); err != nil {
 			errors = append(errors, err)
 		}
 	}

--- a/src/github.com/mozilla-services/pushgo/simplepush/config_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/config_test.go
@@ -159,7 +159,7 @@ func TestLoad(t *testing.T) {
 	var (
 		appInst                                                    *Application
 		mockApp, mockMetrics, mockRouter, mockServ                 *mockPlugin
-		mockSocket, mockEndpoint, mockHealth                       *mockPlugin
+		mockSocket, mockEndpoint, mockHealth, mockProfile          *mockPlugin
 		mockLogger, mockStore, mockPing, mockLocator, mockBalancer *mockPlugin
 	)
 	loader := PluginLoaders{
@@ -263,7 +263,7 @@ func TestLoad(t *testing.T) {
 			h := NewSocketHandler()
 			mockSocket = newMockPlugin(PluginSocket, h)
 			if err := loadEnvConfig(env, "websocket", app, mockSocket); err != nil {
-				return nil, fmt.Errorf("Error initializing WebSocket handlers: %s", err)
+				return nil, fmt.Errorf("Error initializing WebSocket handler: %s", err)
 			}
 			return h, nil
 		},
@@ -276,7 +276,7 @@ func TestLoad(t *testing.T) {
 			h := NewEndpointHandler()
 			mockEndpoint = newMockPlugin(PluginSocket, h)
 			if err := loadEnvConfig(env, "endpoint", app, mockEndpoint); err != nil {
-				return nil, fmt.Errorf("Error initializing update handlers: %s", err)
+				return nil, fmt.Errorf("Error initializing update handler: %s", err)
 			}
 			return h, nil
 		},
@@ -288,6 +288,17 @@ func TestLoad(t *testing.T) {
 			mockHealth = newMockPlugin(PluginHealth, h)
 			if err := mockHealth.Init(app, mockHealth.ConfigStruct()); err != nil {
 				return nil, fmt.Errorf("Error initializing health handlers: %s", err)
+			}
+			return h, nil
+		},
+		PluginProfile: func(app *Application) (HasConfigStruct, error) {
+			if err := isReady(mockLogger); err != nil {
+				return nil, err
+			}
+			h := new(ProfileHandlers)
+			mockProfile = newMockPlugin(PluginProfile, h)
+			if err := mockProfile.Init(app, mockProfile.ConfigStruct()); err != nil {
+				return nil, fmt.Errorf("Error initializing profiling handlers: %s", err)
 			}
 			return h, nil
 		},

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
@@ -88,7 +88,7 @@ func (h *EndpointHandler) Init(app *Application, config interface{}) (err error)
 func (h *EndpointHandler) Listener() net.Listener { return h.listener }
 func (h *EndpointHandler) MaxConns() int          { return h.maxConns }
 func (h *EndpointHandler) URL() string            { return h.url }
-func (h *EndpointHandler) ServeMux() *mux.Router  { return h.mux }
+func (h *EndpointHandler) ServeMux() ServeMux     { return (*RouteMux)(h.mux) }
 
 // setApp sets the parent application for this endpoint handler.
 func (h *EndpointHandler) setApp(app *Application) {

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_pprof.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_pprof.go
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package simplepush
+
+import (
+	"log"
+	"net"
+	"net/http"
+	_ "net/http/pprof"
+)
+
+type ProfileHandlersConfig struct {
+	Enabled  bool
+	Listener ListenerConfig
+}
+
+// ProfileHandlers exposes handlers provided by package net/http/pprof. These
+// are useful for profiling CPU and heap usage during load testing.
+type ProfileHandlers struct {
+	logger   *SimpleLogger
+	listener net.Listener
+	server   *ServeCloser
+	url      string
+	maxConns int
+}
+
+func (p *ProfileHandlers) ConfigStruct() interface{} {
+	return &ProfileHandlersConfig{
+		Enabled: false,
+		Listener: ListenerConfig{
+			Addr:            ":8082",
+			MaxConns:        100,
+			KeepAlivePeriod: "3m",
+		},
+	}
+}
+
+func (p *ProfileHandlers) Init(app *Application, config interface{}) (err error) {
+	conf := config.(*ProfileHandlersConfig)
+	p.logger = app.Logger()
+
+	if !conf.Enabled {
+		return nil
+	}
+
+	if p.listener, err = conf.Listener.Listen(); err != nil {
+		p.logger.Panic("handlers_pprof", "Could not attach profiling listener",
+			LogFields{"error": err.Error()})
+		return err
+	}
+
+	var scheme string
+	if conf.Listener.UseTLS() {
+		scheme = "https"
+	} else {
+		scheme = "http"
+	}
+	host, port := HostPort(p.listener, app)
+	p.url = CanonicalURL(scheme, host, port)
+
+	p.maxConns = conf.Listener.MaxConns
+	p.server = NewServeCloser(&http.Server{
+		Handler: &LogHandler{http.DefaultServeMux, p.logger},
+		ErrorLog: log.New(&LogWriter{
+			Logger: p.logger,
+			Name:   "handlers_profile",
+			Level:  ERROR,
+		}, "", 0),
+	})
+
+	return nil
+}
+
+func (p *ProfileHandlers) Listener() net.Listener { return p.listener }
+func (p *ProfileHandlers) MaxConns() int          { return p.maxConns }
+func (p *ProfileHandlers) URL() string            { return p.url }
+func (p *ProfileHandlers) ServeMux() ServeMux     { return http.DefaultServeMux }
+
+func (p *ProfileHandlers) Start(errChan chan<- error) {
+	if p.server == nil {
+		if p.logger.ShouldLog(INFO) {
+			p.logger.Info("handlers_profile", "Profiling server disabled", nil)
+		}
+		return
+	}
+	if p.logger.ShouldLog(WARNING) {
+		p.logger.Warn("handlers_profile", "Starting profiling server",
+			LogFields{"url": p.url})
+	}
+	errChan <- p.server.Serve(p.listener)
+}
+
+func (p *ProfileHandlers) Close() error {
+	var errors MultipleError
+	if p.listener != nil {
+		if err := p.listener.Close(); err != nil {
+			if p.logger.ShouldLog(ERROR) {
+				p.logger.Error("handlers_profile", "Error closing profiling listener",
+					LogFields{"error": err.Error(), "url": p.url})
+			}
+			errors = append(errors, err)
+		}
+	}
+	if p.server != nil {
+		if err := p.server.Close(); err != nil {
+			if p.logger.ShouldLog(ERROR) {
+				p.logger.Error("handlers_profile", "Error closing profiling server",
+					LogFields{"error": err.Error(), "url": p.url})
+			}
+			errors = append(errors, err)
+		}
+	}
+	if len(errors) > 0 {
+		return errors
+	}
+	return nil
+}

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_socket.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_socket.go
@@ -102,7 +102,7 @@ func (h *SocketHandler) Init(app *Application, config interface{}) (err error) {
 func (h *SocketHandler) Listener() net.Listener { return h.listener }
 func (h *SocketHandler) MaxConns() int          { return h.maxConns }
 func (h *SocketHandler) URL() string            { return h.url }
-func (h *SocketHandler) ServeMux() *mux.Router  { return h.mux }
+func (h *SocketHandler) ServeMux() ServeMux     { return (*RouteMux)(h.mux) }
 
 func (h *SocketHandler) Start(errChan chan<- error) {
 	if h.logger.ShouldLog(INFO) {
@@ -176,14 +176,14 @@ func (h *SocketHandler) close() error {
 	var errors MultipleError
 	if err := h.listener.Close(); err != nil {
 		if h.logger.ShouldLog(ERROR) {
-			h.logger.Error("handlers", "Error closing WebSocket listener",
+			h.logger.Error("handlers_socket", "Error closing WebSocket listener",
 				LogFields{"error": err.Error(), "url": h.url})
 		}
 		errors = append(errors, err)
 	}
 	if err := h.server.Close(); err != nil {
 		if h.logger.ShouldLog(ERROR) {
-			h.logger.Error("handlers", "Error closing WebSocket server",
+			h.logger.Error("handlers_socket", "Error closing WebSocket server",
 				LogFields{"error": err.Error(), "url": h.url})
 		}
 		errors = append(errors, err)

--- a/src/github.com/mozilla-services/pushgo/simplepush/mock_config_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/mock_config_test.go
@@ -28,6 +28,16 @@ func (_m *MockHasConfigStruct) EXPECT() *_MockHasConfigStructRecorder {
 	return _m.recorder
 }
 
+func (_m *MockHasConfigStruct) Init(app *Application, config interface{}) error {
+	ret := _m.ctrl.Call(_m, "Init", app, config)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockHasConfigStructRecorder) Init(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Init", arg0, arg1)
+}
+
 func (_m *MockHasConfigStruct) ConfigStruct() interface{} {
 	ret := _m.ctrl.Call(_m, "ConfigStruct")
 	ret0, _ := ret[0].(interface{})
@@ -38,12 +48,33 @@ func (_mr *_MockHasConfigStructRecorder) ConfigStruct() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigStruct")
 }
 
-func (_m *MockHasConfigStruct) Init(app *Application, config interface{}) error {
+// Mock of HasInit interface
+type MockHasInit struct {
+	ctrl     *gomock.Controller
+	recorder *_MockHasInitRecorder
+}
+
+// Recorder for MockHasInit (not exported)
+type _MockHasInitRecorder struct {
+	mock *MockHasInit
+}
+
+func NewMockHasInit(ctrl *gomock.Controller) *MockHasInit {
+	mock := &MockHasInit{ctrl: ctrl}
+	mock.recorder = &_MockHasInitRecorder{mock}
+	return mock
+}
+
+func (_m *MockHasInit) EXPECT() *_MockHasInitRecorder {
+	return _m.recorder
+}
+
+func (_m *MockHasInit) Init(app *Application, config interface{}) error {
 	ret := _m.ctrl.Call(_m, "Init", app, config)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockHasConfigStructRecorder) Init(arg0, arg1 interface{}) *gomock.Call {
+func (_mr *_MockHasInitRecorder) Init(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Init", arg0, arg1)
 }

--- a/src/github.com/mozilla-services/pushgo/simplepush/mock_handlers_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/mock_handlers_test.go
@@ -4,10 +4,55 @@
 package simplepush
 
 import (
-	gomock "github.com/rafrombrc/gomock/gomock"
+	http "net/http"
 	net "net"
-	mux "github.com/gorilla/mux"
+	gomock "github.com/rafrombrc/gomock/gomock"
 )
+
+// Mock of ServeMux interface
+type MockServeMux struct {
+	ctrl     *gomock.Controller
+	recorder *_MockServeMuxRecorder
+}
+
+// Recorder for MockServeMux (not exported)
+type _MockServeMuxRecorder struct {
+	mock *MockServeMux
+}
+
+func NewMockServeMux(ctrl *gomock.Controller) *MockServeMux {
+	mock := &MockServeMux{ctrl: ctrl}
+	mock.recorder = &_MockServeMuxRecorder{mock}
+	return mock
+}
+
+func (_m *MockServeMux) EXPECT() *_MockServeMuxRecorder {
+	return _m.recorder
+}
+
+func (_m *MockServeMux) Handle(_param0 string, _param1 http.Handler) {
+	_m.ctrl.Call(_m, "Handle", _param0, _param1)
+}
+
+func (_mr *_MockServeMuxRecorder) Handle(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Handle", arg0, arg1)
+}
+
+func (_m *MockServeMux) HandleFunc(_param0 string, _param1 func(http.ResponseWriter, *http.Request)) {
+	_m.ctrl.Call(_m, "HandleFunc", _param0, _param1)
+}
+
+func (_mr *_MockServeMuxRecorder) HandleFunc(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HandleFunc", arg0, arg1)
+}
+
+func (_m *MockServeMux) ServeHTTP(_param0 http.ResponseWriter, _param1 *http.Request) {
+	_m.ctrl.Call(_m, "ServeHTTP", _param0, _param1)
+}
+
+func (_mr *_MockServeMuxRecorder) ServeHTTP(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ServeHTTP", arg0, arg1)
+}
 
 // Mock of Handler interface
 type MockHandler struct {
@@ -60,9 +105,9 @@ func (_mr *_MockHandlerRecorder) URL() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "URL")
 }
 
-func (_m *MockHandler) ServeMux() *mux.Router {
+func (_m *MockHandler) ServeMux() ServeMux {
 	ret := _m.ctrl.Call(_m, "ServeMux")
-	ret0, _ := ret[0].(*mux.Router)
+	ret0, _ := ret[0].(ServeMux)
 	return ret0
 }
 

--- a/src/github.com/mozilla-services/pushgo/simplepush/server_smoke_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/server_smoke_test.go
@@ -192,6 +192,15 @@ func (t *TestServer) load() (*Application, error) {
 			}
 			return h, nil
 		},
+		PluginProfile: func(app *Application) (HasConfigStruct, error) {
+			ph := new(ProfileHandlers)
+			phConf := ph.ConfigStruct().(*ProfileHandlersConfig)
+			phConf.Enabled = false
+			if err := ph.Init(app, phConf); err != nil {
+				return nil, fmt.Errorf("Error initializing profiling handlers: %s", err)
+			}
+			return ph, nil
+		},
 	}
 	return loaders.Load(int(t.LogLevel))
 }


### PR DESCRIPTION
This adds a separate listener for the `net/http/pprof` handlers. It's enabled by default for Docker container builds, and can be toggled via `PUSHGO_PROFILE_ENABLE`.