### PR TITLE
make yak-shave

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -17,7 +17,6 @@ github.com/gorilla/context 14f550f51af52180c2eefed15e5fd18d63c0a64a
 github.com/gorilla/mux 4b8fbc56f3b2400a7c7ea3dba9b3539787c486b6
 github.com/ianoshen/gomc 7b9f299f292d3dd707fe2749d966968c9bf1e128
 github.com/kitcambridge/envconf fdc1968532255bdb56182329cdaa1e5b9aa6a6ac
-github.com/rafrombrc/gomock/gomock c922279faf77f29ce5781e96eb0711837fcb477c
 github.com/smartystreets/goconvey 8298bc7d36389ffd3e57b85d9797850d8c2382a9
 github.com/jacobsa/oglematchers 4fc24f97b5b74022c2a3f4ca7eed57ca29083d3e
 

--- a/Godeps
+++ b/Godeps
@@ -12,7 +12,6 @@ github.com/bbangert/toml a2063ce2e5cf10e54ab24075840593d60f59b611
 github.com/bradfitz/gomemcache/memcache 4faecadd4f695d18a912ba110120fcfd460aca98
 github.com/cactus/go-statsd-client/statsd f934df28073069859c4b8a26e837e0fc55e79d37
 github.com/coreos/go-etcd/etcd 6fe04d580dfb71c9e34cbce2f4df9eefd1e1241e
-github.com/glycerine/go-capnproto d56197a98e456a3b42c3bd9b25ff40a1a8f31420
 github.com/glycerine/rbtree cd7940bb26b149ce2faf398e7c63fff01aa7b394
 github.com/gorilla/context 14f550f51af52180c2eefed15e5fd18d63c0a64a
 github.com/gorilla/mux 4b8fbc56f3b2400a7c7ea3dba9b3539787c486b6
@@ -24,5 +23,6 @@ github.com/jacobsa/oglematchers 4fc24f97b5b74022c2a3f4ca7eed57ca29083d3e
 
 # Installable packages.
 github.com/gogo/protobuf/... d59ce9ecb817e6fbca932115f03520207f5a8a07
+github.com/glycerine/go-capnproto/... d56197a98e456a3b42c3bd9b25ff40a1a8f31420
 github.com/rafrombrc/gomock/... c922279faf77f29ce5781e96eb0711837fcb477c
 github.com/mattn/goveralls eddc233731034b539ce80ec41380bf14efd473d3

--- a/Makefile
+++ b/Makefile
@@ -1,53 +1,75 @@
-SHELL = /bin/sh
-GO = go
-PROTOC = protoc
-CAPNPC = capnpc
+SHELL := /bin/sh
 
-HERE = $(shell pwd)
-BIN = $(HERE)/bin
-GPM = $(HERE)/gpm
-DEPS = $(HERE)/.godeps
-GOPATH = $(DEPS):$(HERE)
-TOOLS = $(shell GOPATH=$(GOPATH) $(GO) tool)
+PROTOC := protoc
+CAPNPC := capnpc
 
-PLATFORM=$(shell uname)
+BIN := $(CURDIR)/bin
+DEPS := $(CURDIR)/.godeps
 
 # Setup commands and env vars if there is no system go linked into bin/go
-PATH := $(HERE)/bin:$(DEPS)/bin:$(PATH)
+PATH := $(CURDIR)/bin:$(DEPS)/bin:$(PATH)
+GOPATH := $(DEPS):$(CURDIR)
+GPM := GOPATH=$(GOPATH) $(CURDIR)/gpm
+GO := GOPATH=$(GOPATH) go
 
-PACKAGE = github.com/mozilla-services/pushgo
-PREFIX = src/$(PACKAGE)/simplepush
-TARGET = simplepush
-COVER_MODE = count
-COVER_PATH = $(HERE)/.coverage
+PLATFORM := $(shell uname)
 
-VERSION = $(strip $(shell [ -e $(HERE)/GITREF ] && cat $(HERE)/GITREF 2>/dev/null))
-ifeq ($(VERSION),)
-	VERSION = $(strip $(shell git describe --tags --always HEAD 2>/dev/null))
-endif
+# All server packages.
+PACKAGE := github.com/mozilla-services/pushgo
+SUBPACKAGES := $(addprefix $(PACKAGE)/,id retry simplepush)
 
-ifneq ($(strip $(VERSION)),)
-	GOLDFLAGS := -X $(PACKAGE)/simplepush.VERSION $(VERSION) $(GOLDFLAGS)
-endif
+# The executable name.
+TARGET := simplepush
 
+# Generated Protobuf and Cap'n Proto targets.
+GEN_TARGETS := log_message.pb.go routable.capnp.go
+GEN_PATHS := $(addprefix $(CURDIR)/src/$(PACKAGE)/simplepush/,\
+	$(GEN_TARGETS))
 
-.PHONY: all build clean test $(TARGET) memcached
+# Interfaces for mocking.
+INTERFACES := config.go worker.go storage.go locator.go metrics.go\
+	balancer.go socket.go handlers.go log.go router.go proprietary_ping.go
+MOCKS := $(addprefix src/$(PACKAGE)/simplepush/,\
+	$(patsubst %.go,mock_%_test.go,$(INTERFACES)))
+
+# Coverage mode; can be "set", "count", or "atomic". See
+# https://blog.golang.org/cover for more info.
+COVER_MODE := count
+
+# Temporary coverage profile paths for each package, and the merged profile
+# targets.
+COVER_PATH := $(CURDIR)/.coverage
+COVER_PACKAGES := $(addprefix $(COVER_PATH)/,\
+	$(addsuffix %.out,$(SUBPACKAGES)))
+COVER_TARGETS := coverage.out coverage.server.out
+COVER_HTML_TARGETS := $(patsubst %.out,%.html,$(COVER_TARGETS))
+
+.PHONY: all build gen clean-gen $(TARGET) test-mocks clean-mocks test \
+	test-server test-gomc test-gomemcache check-cov travis-cov\
+	html-cov html-server-cov clean-cov bench bench-server vet clean
+.INTERMEDIATE: $(COVER_TARGETS)
 
 all: build
 
 $(BIN):
 	mkdir -p $(BIN)
 
+# Fetch and install dependencies.
 $(DEPS):
 	@echo "Installing dependencies"
-	GOPATH=$(GOPATH) $(GPM) install
-	GOPATH=$(GOPATH) $(GO) install github.com/gogo/protobuf/... \
+	$(GPM) install
+	$(GO) install github.com/gogo/protobuf/... \
+		github.com/glycerine/go-capnproto/... \
 		github.com/rafrombrc/gomock/mockgen \
 		github.com/mattn/goveralls
 
 build: $(DEPS)
 
-gen: $(addprefix $(HERE)/$(PREFIX)/,log_message.pb.go routable.capnp.go)
+# Generate Protobuf and Cap'n Proto source files.
+gen: $(GEN_PATHS)
+
+clean-gen:
+	rm -f $(GEN_PATHS)
 
 %.pb.go: %.proto
 	$(PROTOC) -I$(DEPS)/src/github.com/gogo/protobuf/gogoproto \
@@ -73,94 +95,87 @@ endif
 memcached: libmemcached-1.0.18
 	cd libmemcached-1.0.18 && sudo make install
 
+# Build the Simple Push server.
 $(TARGET):
 	rm -f $(TARGET)
 	@echo "Building simplepush"
-	GOPATH=$(GOPATH) $(GO) build \
-		-ldflags "$(GOLDFLAGS)" -tags libmemcached -o $(TARGET) $(PACKAGE)
+	$(GO) build -tags libmemcached -o $(TARGET) $(PACKAGE)
 
-MOCK_INTERFACES = config.go worker.go storage.go locator.go metrics.go\
-	balancer.go server.go socket.go handlers.go log.go router.go\
-	proprietary_ping.go
-
-mock_%_test.go: %.go $(DEPS)
-	mockgen -source=$< -destination=$@ -package="simplepush"
-
-test-mocks: $(addprefix $(PREFIX)/,$(patsubst %.go,mock_%_test.go,\
-	$(MOCK_INTERFACES)))
+# Generate mock interfaces for the tests.
+test-mocks: $(MOCKS)
 
 clean-mocks:
-	rm -f $(addprefix $(PREFIX)/,$(patsubst %.go,mock_%_test.go,\
-		$(MOCK_INTERFACES)))
+	rm -f $(MOCKS)
 
-test-gomc:
-	GOPATH=$(GOPATH) $(GO) test \
-		-tags "smoke memcached_server_test libmemcached" \
-		-ldflags "$(GOLDFLAGS)" $(addprefix $(PACKAGE)/,id retry simplepush)
+mock_%_test.go: %.go
+	mockgen -source=$< -destination=$@ -package="simplepush"
 
-test-gomemcache:
-	GOPATH=$(GOPATH) $(GO) test \
-		-tags "smoke memcached_server_test" \
-		-ldflags "$(GOLDFLAGS)" $(addprefix $(PACKAGE)/,id retry simplepush)
+# Test the server with smoke tests.
+test: $(MOCKS)
+	$(GO) test -v -tags smoke $(SUBPACKAGES)
 
+# Test the server only.
+test-server: $(MOCKS)
+	$(GO) test -v $(SUBPACKAGES)
+
+# Test with smoke tests and the libmemcached adapter. Requires a running
+# memcached cluster; can be set via PUSHGO_TEST_STORAGE_MC_HOSTS.
+test-gomc: $(MOCKS)
+	$(GO) test -tags "smoke memcached_server_test libmemcached" $(SUBPACKAGES)
+
+# Test with smoke tests and the pure-Go gomemcache adapter.
+test-gomemcache: $(MOCKS)
+	$(GO) test -tags "smoke memcached_server_test" $(SUBPACKAGES)
+
+# Ensure `go tool cover` is installed.
 check-cov:
-ifneq (cover,$(filter cover,$(TOOLS)))
-	@echo "Go tool 'Cover' not installed."
-	$(GO) tool cover
-	false
-endif
+	@$(GO) tool -n cover >/dev/null 2>&1 || (echo \
+		"Go tool 'Cover' not installed." && false)
+
+# Generate coverage reports for the server and smoke tests.
+html-cov: coverage.html
+
+# Generate coverage reports for the server only.
+html-server-cov: coverage.server.html
+
+# Upload full coverage profile to Coveralls.
+travis-cov: coverage.out check-cov
+	goveralls -coverprofile=$< -service=travis-ci -repotoken $(COVERALLS_TOKEN)
 
 clean-cov:
 	rm -rf $(COVER_PATH)
-	rm -f $(addprefix coverage,.out .html)
+	rm -f $(COVER_HTML_TARGETS)
 
-cov-dir: clean-cov
-	mkdir -p $(COVER_PATH)
+$(COVER_PATH)/%.out: $(CURDIR)/src/%/*.go $(MOCKS)
+	mkdir -p $(dir $@)
+	$(GO) test -tags smoke -covermode=$(COVER_MODE) -coverprofile=$@ $*
 
-retry-cov: check-cov cov-dir
-	GOPATH=$(GOPATH) $(GO) test \
-		-covermode=$(COVER_MODE) -coverprofile=$(COVER_PATH)/retry.out \
-		-ldflags "$(GOLDFLAGS)" $(PACKAGE)/retry
+$(COVER_PATH)/%.server.out: $(CURDIR)/src/%/*.go $(MOCKS)
+	mkdir -p $(dir $@)
+	$(GO) test -covermode=$(COVER_MODE) -coverprofile=$@ $*
 
-id-cov: check-cov cov-dir
-	GOPATH=$(GOPATH) $(GO) test \
-		-covermode=$(COVER_MODE) -coverprofile=$(COVER_PATH)/id.out \
-		-ldflags "$(GOLDFLAGS)" $(PACKAGE)/id
+# Merge coverage profiles for each package into an intermediate profile.
+# -coverprofile does not support multiple packages; see
+# https://golang.org/issue/6909.
+$(COVER_TARGETS): coverage%.out: $(COVER_PACKAGES)
+	echo "mode: $(COVER_MODE)" > $@
+	grep -h -v "^mode:" $^ >> $@
 
-simplepush-cov: check-cov cov-dir
-	GOPATH=$(GOPATH) $(GO) test \
-		-covermode=$(COVER_MODE) -coverprofile=$(COVER_PATH)/simplepush.out \
-		-tags smoke \
-		-ldflags "$(GOLDFLAGS)" $(PACKAGE)/simplepush
+# Generate HTML coverage reports.
+$(COVER_HTML_TARGETS): %.html: %.out check-cov
+	$(GO) tool cover -html=$< -o $@
 
-# Merge coverage reports for each package. -coverprofile does not support
-# multiple packages; see https://github.com/golang/go/issues/6909.
-test-cov: retry-cov id-cov simplepush-cov
-	echo "mode: $(COVER_MODE)" > coverage.out
-	grep -h -v "^mode:" $(COVER_PATH)/*.out >> coverage.out
+# Benchmark the server and smoke tests.
+bench: $(MOCKS)
+	$(GO) test -v -bench . -benchmem -benchtime=5s -tags smoke $(SUBPACKAGES)
 
-html-cov: test-cov
-	GOPATH=$(GOPATH) $(GO) tool cover \
-		-html=coverage.out -o coverage.html
-
-travis-cov: test-cov
-	GOPATH=$(GOPATH) goveralls -coverprofile=coverage.out \
-		-service=travis-ci -repotoken $(COVERALLS_TOKEN)
-
-test: test-mocks
-	GOPATH=$(GOPATH) $(GO) test -v \
-		-tags smoke \
-		-ldflags "$(GOLDFLAGS)" $(addprefix $(PACKAGE)/,id retry simplepush)
-
-bench:
-#	GOPATH=$(GOPATH) $(GO) test -v -bench=Router -benchmem -benchtime=5s
-	GOPATH=$(GOPATH) $(GO) test -v -bench . -benchmem -benchtime=5s \
-		-tags smoke \
-		-ldflags "$(GOLDFLAGS)" $(addprefix $(PACKAGE)/,id retry simplepush)
+# Benchmark the server only.
+bench-server: $(MOCKS)
+	$(GO) test -v -bench . -benchmem -benchtime=5s $(SUBPACKAGES)
 
 vet:
-	GOPATH=$(GOPATH) $(GO) vet $(addprefix $(PACKAGE)/,client id retry simplepush)
+	$(GO) vet $(SUBPACKAGES)
 
-clean: clean-cov clean-mocks
+clean: clean-cov clean-mocks clean-gen
 	rm -rf bin $(DEPS)
 	rm -f $(TARGET)

--- a/src/github.com/mozilla-services/pushgo/simplepush/app.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/app.go
@@ -15,8 +15,8 @@ import (
 	"time"
 )
 
-// The Simple Push server version, set by the linker.
-var VERSION string
+// The Simple Push server version.
+const VERSION = "1.5.0"
 
 var (
 	ErrMissingOrigin = errors.New("Missing WebSocket origin")


### PR DESCRIPTION
* Add `html-server-cov`, `test-server`, and `bench-server` for testing the server without the smoke tests.
* Add some comments for the variables and recipes.
* Revert the `GOLDFLAGS` trick for setting the version via the linker.
* Install `go-capnproto` so that `capnpc` can use the `capnpc-go` binary.

@jrconlin r?