### PR TITLE
Append the hostname to metrics keys; report goroutine count

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,7 +40,7 @@ Features
   attempt to hold the socket open to the device.
 - Added support for Google Cloud Messaging as a proprietary ping mechanism with
   testing.
-
+- Append the hostname to all emitted metric keys. PR #220, Issue #200.
 
 Bug Fixes
 ---------
@@ -82,6 +82,8 @@ Metrics
     'balancer.etcd.error', 'balancer.etcd.retry'
 - A counter that tracks failed local delivery attempts:
     'updates.appserver.rejected'
+- A gauge that tracks the number of active goroutines. PR #220, Issue #219.
+    'goroutines'
 
 Incompatibilities
 -----------------

--- a/src/github.com/mozilla-services/pushgo/simplepush/app.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/app.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"text/template"
@@ -408,12 +409,14 @@ func (a *Application) close() error {
 }
 
 func (a *Application) sendClientCount() {
+	metrics := a.Metrics()
 	ticker := time.NewTicker(1 * time.Second)
 	for ok := true; ok; {
 		select {
 		case ok = <-a.closeChan:
 		case <-ticker.C:
-			a.Metrics().Gauge("update.client.connections", int64(a.WorkerCount()))
+			metrics.Gauge("goroutines", int64(runtime.NumGoroutine()))
+			metrics.Gauge("update.client.connections", int64(a.WorkerCount()))
 		}
 	}
 	ticker.Stop()

--- a/src/github.com/mozilla-services/pushgo/simplepush/metrics_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/metrics_test.go
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package simplepush
+
+import (
+	"testing"
+
+	"github.com/rafrombrc/gomock/gomock"
+)
+
+func TestMetricsFormat(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mckLogger := NewMockLogger(mockCtrl)
+	mckLogger.EXPECT().ShouldLog(gomock.Any()).Return(true).AnyTimes()
+	mckLogger.EXPECT().Log(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any()).AnyTimes()
+
+	tests := []struct {
+		name     string
+		hostname string
+		prefix   string
+		metric   string
+		tags     []string
+		expected string
+	}{
+		{
+			name:     "Empty hostname and prefix",
+			metric:   "goroutines",
+			expected: "goroutines",
+		},
+		{
+			name:     "Hostname; empty prefix",
+			hostname: "localhost",
+			metric:   "socket.connect",
+			expected: "socket.connect.localhost",
+		},
+		{
+			name:     "FQDN; empty prefix",
+			hostname: "test.mozilla.org",
+			metric:   "socket.disconnect",
+			expected: "socket.disconnect.test-mozilla-org",
+		},
+		{
+			name:     "Empty hostname; prefix",
+			prefix:   "pushgo.hello",
+			metric:   "updates.rejected",
+			expected: "pushgo.hello.updates.rejected"},
+		{
+			name:     "IPv4; prefix",
+			hostname: "127.0.0.1",
+			prefix:   "pushgo.gcm",
+			metric:   "updates.received",
+			expected: "pushgo.gcm.updates.received.127-0-0-1"},
+		{
+			name:     "IPv6; tags",
+			hostname: "::1",
+			metric:   "ping.success",
+			tags:     []string{"stats", "counter"},
+			expected: "stats.counter.ping.success.--1"},
+		{
+			name:     "FQDN; prefix; tags",
+			hostname: "test.mozilla.org",
+			prefix:   "pushgo.simplepush",
+			metric:   "updates.routed.outgoing",
+			tags:     []string{"counter"},
+			expected: "pushgo.simplepush.counter.updates.routed.outgoing.test-mozilla-org"},
+	}
+	for _, test := range tests {
+		app := NewApplication()
+		app.hostname = test.hostname
+		app.SetLogger(mckLogger)
+		m := new(Metrics)
+		if err := m.Init(app, &MetricsConfig{StatsdServer: ""}); err != nil {
+			t.Errorf("On test %s, error initializing metrics: %s", err)
+			continue
+		}
+		m.Prefix(test.prefix)
+		actual := m.formatMetric(test.metric, test.tags...)
+		if actual != test.expected {
+			t.Errorf("On test %s, wrong stat name: got %q; want %q",
+				test.name, actual, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
This pull request appends the hostname to all metric keys sent to statsd. We could provide a generic `Suffix` setter to match the prefix, though I didn't expose this to avoid config changes. Additionally, the goroutine count is now emitted as a gauge, along with the (suspect) connection count.

Closes #200. Closes #219.