### PR TITLE
Disable server-sent pongs by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,8 +36,8 @@ Features
 - New config option for specifying the shutdown delay for [discovery] and
   [balancer]. PR #178.
     close_delay
-- Added client "pong" function. This generates a server side protocol ping to
-  attempt to hold the socket open to the device.
+- Added client "pong" function, disabled by default. This generates a server
+  side protocol ping to attempt to hold the socket open to the device.
 - Added support for Google Cloud Messaging as a proprietary ping mechanism with
   testing.
 - Append the hostname to all emitted metric keys. PR #220, Issue #200.

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -38,7 +38,7 @@
 #client_hello_timeout = "30s"
 # Client Pong Interval is the period for when the server should send a text
 # ping frame. Set to "0" for no server pings
-#client_pong_interval = "5m"
+#client_pong_interval = "0"
 
 [websocket]
 # A list of allowed WebSocket origins. An empty list allows all origins;

--- a/src/github.com/mozilla-services/pushgo/simplepush/app.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/app.go
@@ -83,7 +83,6 @@ func (a *Application) ConfigStruct() interface{} {
 		ResolveHost:        false,
 		ClientMinPing:      "20s",
 		ClientHelloTimeout: "30s",
-		ClientPongInterval: "5m",
 	}
 }
 
@@ -120,9 +119,11 @@ func (a *Application) Init(_ *Application, config interface{}) (err error) {
 		return fmt.Errorf("Unable to parse 'client_min_ping_interval': %s",
 			err.Error())
 	}
-	if a.clientPongInterval, err = time.ParseDuration(conf.ClientPongInterval); err != nil {
-		return fmt.Errorf("Unable to parse 'client_pong_interval': %s",
-			err.Error())
+	if len(conf.ClientPongInterval) > 0 {
+		if a.clientPongInterval, err = time.ParseDuration(conf.ClientPongInterval); err != nil {
+			return fmt.Errorf("Unable to parse 'client_pong_interval': %s",
+				err.Error())
+		}
 	}
 	if a.clientHelloTimeout, err = time.ParseDuration(conf.ClientHelloTimeout); err != nil {
 		return fmt.Errorf("Unable to parse 'client_hello_timeout': %s",


### PR DESCRIPTION
Last 1.5 ticket...don't send pongs unless the `client_pong_interval` option is explicitly specified.

@jrconlin r?