### PR TITLE
Docker build fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ MAINTAINER Ben Bangert <bbangert@mozilla.com>
 # we need to build it, build it, then remove all the stuff we made to build it
 # so that this docker layer only contains the libmemcached addition
 RUN \
+	apt-get update; \
 	apt-get install --no-install-recommends -y -q bzr automake flex bison libtool cloog-ppl wget; \
 	cd /usr/local/src; \
 	wget https://launchpad.net/libmemcached/1.0/1.0.18/+download/libmemcached-1.0.18.tar.gz; \

--- a/Godeps
+++ b/Godeps
@@ -22,6 +22,6 @@ github.com/jacobsa/oglematchers 4fc24f97b5b74022c2a3f4ca7eed57ca29083d3e
 
 # Installable packages.
 github.com/gogo/protobuf/... d59ce9ecb817e6fbca932115f03520207f5a8a07
-github.com/glycerine/go-capnproto/... bcaa96eba53bcffef7006dd987728357995e18f6
+github.com/glycerine/go-capnproto/... c082c595166badf95e5a2e973f5dd4ca9d4c0cdb
 github.com/rafrombrc/gomock/... c922279faf77f29ce5781e96eb0711837fcb477c
 github.com/mattn/goveralls eddc233731034b539ce80ec41380bf14efd473d3

--- a/src/github.com/mozilla-services/pushgo/simplepush/routable.capnp.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/routable.capnp.go
@@ -11,6 +11,7 @@ type Routable C.Struct
 
 func NewRoutable(s *C.Segment) Routable      { return Routable(s.NewStruct(16, 2)) }
 func NewRootRoutable(s *C.Segment) Routable  { return Routable(s.NewRootStruct(16, 2)) }
+func AutoNewRoutable(s *C.Segment) Routable  { return Routable(s.NewStructAR(16, 2)) }
 func ReadRootRoutable(s *C.Segment) Routable { return Routable(s.Root(0).ToStruct()) }
 func (s Routable) ChannelID() string         { return C.Struct(s).GetObject(0).ToText() }
 func (s Routable) SetChannelID(v string)     { C.Struct(s).SetObject(0, s.Segment.NewText(v)) }


### PR DESCRIPTION
* Run `apt-get update` before building `libmemcached` to avoid errors caused by outdated mirrors.
* Fix the `go-capnproto` version and regenerate the `Routable` binding.

@bbangert r?