### PR TITLE
Allow custom affixes per metric type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,7 +40,9 @@ Features
   side protocol ping to attempt to hold the socket open to the device.
 - Added support for Google Cloud Messaging as a proprietary ping mechanism with
   testing.
-- Append the hostname to all emitted metric keys. PR #220, Issue #200.
+- Allow custom prefixes and suffixes for each metric type, with optional
+  variable interpolation. The hostname is appended as a suffix to all emitted
+  gauges by default. PR #228, Issue #200.
 
 Bug Fixes
 ---------

--- a/config.docker.toml
+++ b/config.docker.toml
@@ -165,7 +165,6 @@ type = "static"
 
 [metrics]
 store_snapshots = false
-prefix = "docker"
 statsd_name = "pushgo"
 statsd_server = ":8125"
 

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -251,8 +251,6 @@ type = "static"
 [metrics]
 # The statsd client name, prepended to all metric names.
 #statsd_name = "undef"
-# Optional prefix for metric names, appended to the client name.
-#prefix = "myhostname.simplepush"
 #statsd_server = "heka_statsdinput_host:1234"
 
 [balancer]

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -253,6 +253,20 @@ type = "static"
 #statsd_name = "undef"
 #statsd_server = "heka_statsdinput_host:1234"
 
+# Optional metric name affixes for counters, timers, and gauges. May contain
+# the following substitutions:
+# {{.Host}} - The current hostname, as set by default.current_host.
+# {{.Version}} - The server version.
+#[metrics.counters]
+#prefix = "simplepush"
+
+#[metrics.timers]
+#prefix = "simplepush"
+
+#[metrics.gauges]
+#prefix = "simplepush"
+#suffix = "{{.Host}}"
+
 [balancer]
 type = "none"
 

--- a/src/github.com/mozilla-services/pushgo/simplepush/metrics.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/metrics.go
@@ -5,9 +5,11 @@
 package simplepush
 
 import (
+	"bytes"
 	"strconv"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
 	"github.com/cactus/go-statsd-client/statsd"
@@ -32,16 +34,22 @@ type trec struct {
 
 type timer map[string]trec
 
+type MetricConfig struct {
+	Prefix string
+	Suffix string
+}
+
 type MetricsConfig struct {
 	StoreSnapshots bool   `toml:"store_snapshots" env:"store_snapshots"`
-	Prefix         string `env:"prefix"`
 	StatsdServer   string `toml:"statsd_server" env:"statsd_server"`
 	StatsdName     string `toml:"statsd_name" env:"statsd_name"`
+	Counters       MetricConfig
+	Timers         MetricConfig
+	Gauges         MetricConfig
 }
 
 type Statistician interface {
 	Init(*Application, interface{}) error
-	Prefix(string)
 	Snapshot() map[string]interface{}
 	IncrementBy(string, int64)
 	Increment(string)
@@ -53,30 +61,39 @@ type Statistician interface {
 
 type Metrics struct {
 	sync.RWMutex
-	counter        map[string]int64 // counters
-	timer          timer            // timers
-	gauge          map[string]int64
-	prefix         string // prefix for
+
+	counter       map[string]int64 // Counter snapshots.
+	counterPrefix string           // Optional prefix for counter names.
+	counterSuffix string           // Optional suffix for counter names.
+
+	timer       timer // Timer snapshots.
+	timerPrefix string
+	timerSuffix string
+
+	gauge       map[string]int64 // Gauge snapshots.
+	gaugePrefix string
+	gaugeSuffix string
+
+	app            *Application
 	logger         *SimpleLogger
 	statsd         *statsd.Client
 	born           time.Time
 	storeSnapshots bool
-	hostname       string
 }
 
 func (m *Metrics) ConfigStruct() interface{} {
 	return &MetricsConfig{
 		StoreSnapshots: true,
-		Prefix:         "simplepush",
 		StatsdName:     "undef",
+		Counters:       MetricConfig{Prefix: "simplepush"},
+		Timers:         MetricConfig{Prefix: "simplepush"},
+		Gauges:         MetricConfig{Prefix: "simplepush", Suffix: "{{.Host}}"},
 	}
 }
 
 func (m *Metrics) Init(app *Application, config interface{}) (err error) {
 	conf := config.(*MetricsConfig)
-
-	m.logger = app.Logger()
-	m.hostname = strings.Map(cleanMetricPart, app.Hostname())
+	m.setApp(app)
 
 	if conf.StatsdServer != "" {
 		name := strings.ToLower(conf.StatsdName)
@@ -87,7 +104,24 @@ func (m *Metrics) Init(app *Application, config interface{}) (err error) {
 		}
 	}
 
-	m.Prefix(conf.Prefix)
+	err = m.setCounterAffixes(conf.Counters.Prefix, conf.Counters.Suffix)
+	if err != nil {
+		m.logger.Panic("metrics", "Error setting counter name affixes",
+			LogFields{"error": err.Error()})
+		return err
+	}
+	err = m.setTimerAffixes(conf.Timers.Prefix, conf.Timers.Suffix)
+	if err != nil {
+		m.logger.Panic("metrics", "Error setting timer name affixes",
+			LogFields{"error": err.Error()})
+		return err
+	}
+	err = m.setGaugeAffixes(conf.Gauges.Prefix, conf.Gauges.Suffix)
+	if err != nil {
+		m.logger.Panic("metrics", "Error parsing gauge name affixes",
+			LogFields{"error": err.Error()})
+		return err
+	}
 	m.born = time.Now()
 
 	if m.storeSnapshots = conf.StoreSnapshots; m.storeSnapshots {
@@ -99,21 +133,90 @@ func (m *Metrics) Init(app *Application, config interface{}) (err error) {
 	return nil
 }
 
-func (m *Metrics) Prefix(newPrefix string) {
-	m.prefix = strings.TrimRight(newPrefix, ".")
+func (m *Metrics) setApp(app *Application) {
+	m.app = app
+	m.logger = app.Logger()
 }
 
-func (m *Metrics) formatMetric(metric string, tags ...string) string {
+func (m *Metrics) setCounterAffixes(rawPrefix, rawSuffix string) (err error) {
+	m.counterPrefix, err = m.formatAffix("counterPrefix", rawPrefix)
+	if err != nil {
+		return err
+	}
+	m.counterSuffix, err = m.formatAffix("counterSuffix", rawSuffix)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Metrics) setTimerAffixes(rawPrefix, rawSuffix string) (err error) {
+	if m.timerPrefix, err = m.formatAffix("timerPrefix", rawPrefix); err != nil {
+		return err
+	}
+	if m.timerSuffix, err = m.formatAffix("timerSuffix", rawSuffix); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Metrics) setGaugeAffixes(rawPrefix, rawSuffix string) (err error) {
+	if m.gaugePrefix, err = m.formatAffix("gaugePrefix", rawPrefix); err != nil {
+		return err
+	}
+	if m.gaugeSuffix, err = m.formatAffix("gaugeSuffix", rawSuffix); err != nil {
+		return err
+	}
+	return nil
+}
+
+// formatAffix parses a raw affix as a template, interpolating the hostname
+// and server version into the resulting string.
+func (m *Metrics) formatAffix(name, raw string) (string, error) {
+	tmpl, err := template.New(name).Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	affix := new(bytes.Buffer)
+	host := strings.Map(cleanMetricPart, m.app.Hostname())
+	params := struct {
+		Host    string
+		Version string
+	}{host, VERSION}
+	if err := tmpl.Execute(affix, params); err != nil {
+		return "", err
+	}
+	cleanAffix := bytes.TrimRight(affix.Bytes(), ".")
+	return string(cleanAffix), nil
+}
+
+func (m *Metrics) formatCounter(metric string, tags ...string) string {
+	return m.formatMetric(metric, m.counterPrefix, m.counterSuffix, tags...)
+}
+
+func (m *Metrics) formatTimer(metric string, tags ...string) string {
+	return m.formatMetric(metric, m.timerPrefix, m.timerSuffix, tags...)
+}
+
+func (m *Metrics) formatGauge(metric string, tags ...string) string {
+	return m.formatMetric(metric, m.gaugePrefix, m.gaugeSuffix, tags...)
+}
+
+// formatMetric constructs a statsd key from the given metric name, prefix,
+// and suffix. Additional tags are prepended to the suffix.
+func (m *Metrics) formatMetric(metric string, prefix, suffix string,
+	tags ...string) string {
+
 	var parts []string
-	if len(m.prefix) > 0 {
-		parts = append(parts, m.prefix)
+	if len(prefix) > 0 {
+		parts = append(parts, prefix)
 	}
 	if len(tags) > 0 {
 		parts = append(parts, tags...)
 	}
 	parts = append(parts, metric)
-	if len(m.hostname) > 0 {
-		parts = append(parts, m.hostname)
+	if len(suffix) > 0 {
+		parts = append(parts, suffix)
 	}
 	return strings.Join(parts, ".")
 }
@@ -126,16 +229,17 @@ func (m *Metrics) Snapshot() map[string]interface{} {
 	// copy the old metrics
 	m.RLock()
 	for k, v := range m.counter {
-		oldMetrics[m.formatMetric(k, "counter")] = v
+		oldMetrics[m.formatCounter(k, "counter")] = v
 	}
 	for k, v := range m.timer {
-		oldMetrics[m.formatMetric(k, "avg")] = v.Avg
+		oldMetrics[m.formatTimer(k, "avg")] = v.Avg
 	}
 	for k, v := range m.gauge {
-		oldMetrics[m.formatMetric(k, "gauge")] = v
+		oldMetrics[m.formatGauge(k, "gauge")] = v
 	}
 	m.RUnlock()
-	oldMetrics[m.formatMetric("server.age")] = time.Now().Unix() - m.born.Unix()
+	age := time.Now().Unix() - m.born.Unix()
+	oldMetrics[m.formatMetric("server.age", "", "")] = age
 	return oldMetrics
 }
 
@@ -155,9 +259,9 @@ func (m *Metrics) IncrementBy(metric string, count int64) {
 
 	if statsd := m.statsd; statsd != nil {
 		if count >= 0 {
-			statsd.Inc(m.formatMetric(metric), count, 1.0)
+			statsd.Inc(m.formatCounter(metric), count, 1.0)
 		} else {
-			statsd.Dec(m.formatMetric(metric), count, 1.0)
+			statsd.Dec(m.formatCounter(metric), count, 1.0)
 		}
 	}
 }
@@ -196,7 +300,7 @@ func (m *Metrics) Timer(metric string, duration time.Duration) {
 				"type": "timer"})
 	}
 	if m.statsd != nil {
-		m.statsd.Timing(m.formatMetric(metric), value, 1.0)
+		m.statsd.Timing(m.formatTimer(metric), value, 1.0)
 	}
 }
 
@@ -209,14 +313,14 @@ func (m *Metrics) Gauge(metric string, value int64) {
 
 	if statsd := m.statsd; statsd != nil {
 		if value >= 0 {
-			statsd.Gauge(m.formatMetric(metric), value, 1.0)
+			statsd.Gauge(m.formatGauge(metric), value, 1.0)
 			return
 		}
 		// Gauges cannot be set to negative values; sign prefixes indicate deltas.
-		if err := statsd.Gauge(m.formatMetric(metric), 0, 1.0); err != nil {
+		if err := statsd.Gauge(m.formatGauge(metric), 0, 1.0); err != nil {
 			return
 		}
-		statsd.GaugeDelta(m.formatMetric(metric), value, 1.0)
+		statsd.GaugeDelta(m.formatGauge(metric), value, 1.0)
 	}
 }
 
@@ -229,7 +333,7 @@ func (m *Metrics) GaugeDelta(metric string, delta int64) {
 	}
 
 	if m.statsd != nil {
-		m.statsd.GaugeDelta(m.formatMetric(metric), delta, 1.0)
+		m.statsd.GaugeDelta(m.formatGauge(metric), delta, 1.0)
 	}
 }
 
@@ -246,7 +350,6 @@ func (r *TestMetrics) Init(app *Application, config interface{}) (err error) {
 	return
 }
 
-func (r *TestMetrics) Prefix(string) {}
 func (r *TestMetrics) Snapshot() map[string]interface{} {
 	return make(map[string]interface{})
 }

--- a/src/github.com/mozilla-services/pushgo/simplepush/metrics_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/metrics_test.go
@@ -20,69 +20,114 @@ func TestMetricsFormat(t *testing.T) {
 		gomock.Any()).AnyTimes()
 
 	tests := []struct {
-		name     string
-		hostname string
-		prefix   string
-		metric   string
-		tags     []string
-		expected string
+		name      string
+		hostname  string
+		prefix    string
+		metric    string
+		tags      []string
+		asCounter string
+		asTimer   string
+		asGauge   string
 	}{
 		{
-			name:     "Empty hostname and prefix",
-			metric:   "goroutines",
-			expected: "goroutines",
+			name:      "Empty hostname and prefix",
+			metric:    "goroutines",
+			asCounter: "goroutines",
+			asTimer:   "goroutines",
+			asGauge:   "goroutines",
 		},
 		{
-			name:     "Hostname; empty prefix",
-			hostname: "localhost",
-			metric:   "socket.connect",
-			expected: "socket.connect.localhost",
+			name:      "Hostname; empty prefix",
+			hostname:  "localhost",
+			metric:    "socket.connect",
+			asCounter: "socket.connect",
+			asTimer:   "socket.connect",
+			asGauge:   "socket.connect.localhost",
 		},
 		{
-			name:     "FQDN; empty prefix",
-			hostname: "test.mozilla.org",
-			metric:   "socket.disconnect",
-			expected: "socket.disconnect.test-mozilla-org",
+			name:      "FQDN; empty prefix",
+			hostname:  "test.mozilla.org",
+			metric:    "socket.disconnect",
+			asCounter: "socket.disconnect",
+			asTimer:   "socket.disconnect",
+			asGauge:   "socket.disconnect.test-mozilla-org",
 		},
 		{
-			name:     "Empty hostname; prefix",
-			prefix:   "pushgo.hello",
-			metric:   "updates.rejected",
-			expected: "pushgo.hello.updates.rejected"},
+			name:      "Empty hostname; prefix",
+			prefix:    "pushgo.hello",
+			metric:    "updates.rejected",
+			asCounter: "pushgo.hello.updates.rejected",
+			asTimer:   "pushgo.hello.updates.rejected",
+			asGauge:   "pushgo.hello.updates.rejected",
+		},
 		{
-			name:     "IPv4; prefix",
-			hostname: "127.0.0.1",
-			prefix:   "pushgo.gcm",
-			metric:   "updates.received",
-			expected: "pushgo.gcm.updates.received.127-0-0-1"},
+			name:      "IPv4; prefix",
+			hostname:  "127.0.0.1",
+			prefix:    "pushgo.gcm",
+			metric:    "updates.received",
+			asCounter: "pushgo.gcm.updates.received",
+			asTimer:   "pushgo.gcm.updates.received",
+			asGauge:   "pushgo.gcm.updates.received.127-0-0-1",
+		},
 		{
-			name:     "IPv6; tags",
-			hostname: "::1",
-			metric:   "ping.success",
-			tags:     []string{"stats", "counter"},
-			expected: "stats.counter.ping.success.--1"},
+			name:      "IPv6; tags",
+			hostname:  "::1",
+			metric:    "ping.success",
+			tags:      []string{"stats", "counter"},
+			asCounter: "stats.counter.ping.success",
+			asTimer:   "stats.counter.ping.success",
+			asGauge:   "stats.counter.ping.success.--1",
+		},
 		{
-			name:     "FQDN; prefix; tags",
-			hostname: "test.mozilla.org",
-			prefix:   "pushgo.simplepush",
-			metric:   "updates.routed.outgoing",
-			tags:     []string{"counter"},
-			expected: "pushgo.simplepush.counter.updates.routed.outgoing.test-mozilla-org"},
+			name:      "FQDN; prefix; tags",
+			hostname:  "test.mozilla.org",
+			prefix:    "pushgo.simplepush",
+			metric:    "updates.routed.outgoing",
+			tags:      []string{"counter"},
+			asCounter: "pushgo.simplepush.counter.updates.routed.outgoing",
+			asTimer:   "pushgo.simplepush.counter.updates.routed.outgoing",
+			asGauge:   "pushgo.simplepush.counter.updates.routed.outgoing.test-mozilla-org",
+		},
 	}
 	for _, test := range tests {
 		app := NewApplication()
 		app.hostname = test.hostname
 		app.SetLogger(mckLogger)
 		m := new(Metrics)
-		if err := m.Init(app, &MetricsConfig{StatsdServer: ""}); err != nil {
-			t.Errorf("On test %s, error initializing metrics: %s", err)
+		m.setApp(app)
+		// Test the default affixes.
+		conf := m.ConfigStruct().(*MetricsConfig)
+		err := m.setCounterAffixes(test.prefix, conf.Counters.Suffix)
+		if err != nil {
+			t.Errorf("On test %s, error setting counter name affixes: %s",
+				test.name, err)
 			continue
 		}
-		m.Prefix(test.prefix)
-		actual := m.formatMetric(test.metric, test.tags...)
-		if actual != test.expected {
-			t.Errorf("On test %s, wrong stat name: got %q; want %q",
-				test.name, actual, test.expected)
+		if err = m.setTimerAffixes(test.prefix, conf.Timers.Suffix); err != nil {
+			t.Errorf("On test %s, error setting timer name affixes: %s",
+				test.name, err)
+			continue
+		}
+		if err = m.setGaugeAffixes(test.prefix, conf.Gauges.Suffix); err != nil {
+			t.Errorf("On test %s, error setting gauge name affixes: %s",
+				test.name, err)
+			continue
+		}
+		app.SetMetrics(m)
+		asCounter := m.formatCounter(test.metric, test.tags...)
+		if asCounter != test.asCounter {
+			t.Errorf("On test %s, wrong counter stat name: got %q; want %q",
+				test.name, asCounter, test.asCounter)
+		}
+		asTimer := m.formatTimer(test.metric, test.tags...)
+		if asTimer != test.asTimer {
+			t.Errorf("On test %s, wrong timer stat name: got %q; want %q",
+				test.name, asTimer, test.asTimer)
+		}
+		asGauge := m.formatGauge(test.metric, test.tags...)
+		if asGauge != test.asGauge {
+			t.Errorf("On test %s, wrong gauge stat name: got %q; want %q",
+				test.name, asGauge, test.asGauge)
 		}
 	}
 }

--- a/src/github.com/mozilla-services/pushgo/simplepush/mock_metrics_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/mock_metrics_test.go
@@ -39,14 +39,6 @@ func (_mr *_MockStatisticianRecorder) Init(arg0, arg1 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Init", arg0, arg1)
 }
 
-func (_m *MockStatistician) Prefix(_param0 string) {
-	_m.ctrl.Call(_m, "Prefix", _param0)
-}
-
-func (_mr *_MockStatisticianRecorder) Prefix(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Prefix", arg0)
-}
-
 func (_m *MockStatistician) Snapshot() map[string]interface{} {
 	ret := _m.ctrl.Call(_m, "Snapshot")
 	ret0, _ := ret[0].(map[string]interface{})


### PR DESCRIPTION
This pull request adds custom prefixes and suffixes for each metric type. The hostname is now only appended to all emitted gauges by default.

The `handlers_test.go` change is unrelated to the affixes, but fixes a local test failure if a server is already listening on the default ports.

@bbangert r?