### PR TITLE
Remove the default metric name prefix

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -250,7 +250,6 @@ type = "static"
 
 [metrics]
 # The statsd client name, prepended to all metric names.
-#statsd_name = "undef"
 #statsd_server = "heka_statsdinput_host:1234"
 
 # Optional metric name affixes for counters, timers, and gauges. May contain
@@ -258,13 +257,15 @@ type = "static"
 # {{.Host}} - The current hostname, as set by default.current_host.
 # {{.Version}} - The server version.
 #[metrics.counters]
-#prefix = "simplepush"
+#prefix = ""
+#suffix = ""
 
 #[metrics.timers]
-#prefix = "simplepush"
+#prefix = ""
+#suffix = ""
 
 #[metrics.gauges]
-#prefix = "simplepush"
+#prefix = ""
 #suffix = "{{.Host}}"
 
 [balancer]

--- a/src/github.com/mozilla-services/pushgo/simplepush/metrics.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/metrics.go
@@ -84,10 +84,7 @@ type Metrics struct {
 func (m *Metrics) ConfigStruct() interface{} {
 	return &MetricsConfig{
 		StoreSnapshots: true,
-		StatsdName:     "undef",
-		Counters:       MetricConfig{Prefix: "simplepush"},
-		Timers:         MetricConfig{Prefix: "simplepush"},
-		Gauges:         MetricConfig{Prefix: "simplepush", Suffix: "{{.Host}}"},
+		Gauges:         MetricConfig{Suffix: "{{.Host}}"},
 	}
 }
 


### PR DESCRIPTION
Removing this footgun for @bbangert's sanity. :frog: