### PR TITLE
Fix skewed routing metrics for `AlwaysRoute`

### DIFF
--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
@@ -347,6 +347,7 @@ func (h *EndpointHandler) deliver(cn http.CloseNotifier, uaid, chid string,
 			// Routing succeeded.
 			h.metrics.Increment("router.broadcast.hit")
 			h.metrics.Timer("updates.routed.hits", routingTime)
+			h.metrics.Increment("updates.appserver.received")
 			return true
 		}
 	}

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint_test.go
@@ -504,6 +504,7 @@ func TestEndpointDelivery(t *testing.T) {
 						"", "").Return(true, nil),
 					mckStat.EXPECT().Increment("router.broadcast.hit"),
 					mckStat.EXPECT().Timer("updates.routed.hits", gomock.Any()),
+					mckStat.EXPECT().Increment("updates.appserver.received"),
 				)
 				ok := eh.deliver(nil, uaid, chid, 3, "", "")
 				So(ok, ShouldBeTrue)

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint_test.go
@@ -502,6 +502,8 @@ func TestEndpointDelivery(t *testing.T) {
 					mckStat.EXPECT().Increment("updates.routed.outgoing"),
 					mckRouter.EXPECT().Route(nil, uaid, chid, int64(3), timeNow().UTC(),
 						"", "").Return(true, nil),
+					mckStat.EXPECT().Increment("router.broadcast.hit"),
+					mckStat.EXPECT().Timer("updates.routed.hits", gomock.Any()),
 				)
 				ok := eh.deliver(nil, uaid, chid, 3, "", "")
 				So(ok, ShouldBeTrue)
@@ -525,6 +527,8 @@ func TestEndpointDelivery(t *testing.T) {
 					mckStat.EXPECT().Increment("updates.routed.outgoing"),
 					mckRouter.EXPECT().Route(nil, "123", "456", int64(1),
 						gomock.Any(), "reqID", "").Return(false, nil),
+					mckStat.EXPECT().Increment("router.broadcast.miss"),
+					mckStat.EXPECT().Timer("updates.routed.misses", gomock.Any()),
 				)
 				eh.ServeMux().ServeHTTP(resp, req)
 

--- a/src/github.com/mozilla-services/pushgo/simplepush/locator_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/locator_test.go
@@ -196,14 +196,6 @@ func TestLocatorReadyNotify(t *testing.T) {
 
 	// First and second routing attempts to self.
 	sndStat.EXPECT().Increment("updates.routed.unknown").Times(2)
-	// First routing attempt to peer.
-	sndStat.EXPECT().Increment("router.broadcast.miss")
-	sndStat.EXPECT().Timer("updates.routed.misses", gomock.Any())
-	sndStat.EXPECT().Timer("router.handled", gomock.Any())
-	// Second routing attempt to peer.
-	sndStat.EXPECT().Increment("router.broadcast.hit")
-	sndStat.EXPECT().Timer("updates.routed.hits", gomock.Any())
-	sndStat.EXPECT().Timer("router.handled", gomock.Any())
 
 	// Initial routing attempt to peer.
 	recvStat.EXPECT().Increment("updates.routed.unknown")

--- a/src/github.com/mozilla-services/pushgo/simplepush/router_broadcast.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/router_broadcast.go
@@ -354,7 +354,6 @@ func (r *BroadcastRouter) Route(cancelSignal <-chan bool, uaid, chid string,
 	version int64, sentAt time.Time, logID string, data string) (
 	delivered bool, err error) {
 
-	startTime := time.Now()
 	locator := r.app.Locator()
 	if locator == nil {
 		if r.logger.ShouldLog(ERROR) {
@@ -393,7 +392,6 @@ func (r *BroadcastRouter) Route(cancelSignal <-chan bool, uaid, chid string,
 			"time":    strconv.FormatInt(sentAt.UnixNano(), 10)})
 	}
 	delivered, err = r.notifyAll(cancelSignal, contacts, uaid, segment, logID)
-	endTime := time.Now()
 	if err != nil {
 		if r.logger.ShouldLog(WARNING) {
 			r.logger.Warn("router", "Could not post to server",
@@ -402,17 +400,6 @@ func (r *BroadcastRouter) Route(cancelSignal <-chan bool, uaid, chid string,
 		r.metrics.Increment("router.broadcast.error")
 		return false, err
 	}
-	var counterName, timerName string
-	if delivered {
-		counterName = "router.broadcast.hit"
-		timerName = "updates.routed.hits"
-	} else {
-		counterName = "router.broadcast.miss"
-		timerName = "updates.routed.misses"
-	}
-	r.metrics.Increment(counterName)
-	r.metrics.Timer(timerName, endTime.Sub(sentAt))
-	r.metrics.Timer("router.handled", endTime.Sub(startTime))
 	return delivered, nil
 }
 

--- a/src/github.com/mozilla-services/pushgo/simplepush/router_broadcast_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/router_broadcast_test.go
@@ -69,8 +69,6 @@ func TestBroadcastRouter(t *testing.T) {
 			gomock.Any(), gomock.Any()).Times(2)
 		mckStat.EXPECT().Increment("router.dial.success").AnyTimes()
 		mckStat.EXPECT().Increment("router.dial.error").AnyTimes()
-		mckStat.EXPECT().Increment("router.broadcast.miss").Times(1)
-		mckStat.EXPECT().Timer(gomock.Any(), gomock.Any()).Times(2)
 		delivered, err := router.Route(cancelSignal, uaid, chid, version, sentAt,
 			"", "")
 		So(err, ShouldBeNil)
@@ -109,9 +107,6 @@ func TestBroadcastRouter(t *testing.T) {
 		mckStat.EXPECT().Increment("updates.routed.received")
 		mckStat.EXPECT().Increment("router.dial.success").AnyTimes()
 		mckStat.EXPECT().Increment("router.dial.error").AnyTimes()
-		mckStat.EXPECT().Increment("router.broadcast.hit")
-		mckStat.EXPECT().Timer("updates.routed.hits", gomock.Any())
-		mckStat.EXPECT().Timer("router.handled", gomock.Any())
 
 		delivered, err := router.Route(cancelSignal, uaid, chid, version, sentAt,
 			"", "")


### PR DESCRIPTION
* If routing succeeds—regardless of whether the device is disconnected or `AlwaysRoute` is enabled, emit `router.broadcast.hit` and `updates.routed.hits`.
* Otherwise, if routing fails and the device is not connected, emit `router.broadcast.miss` and `updates.routed.misses`.
* With this change, `router.handled` is redundant and has been removed.

@bbangert r?