### PR TITLE
Bug/local deliver on always route

### DIFF
--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
@@ -330,10 +330,10 @@ func (h *EndpointHandler) deliver(cn http.CloseNotifier, uaid, chid string,
 	worker, workerConnected := h.app.GetWorker(uaid)
 	var routingTime time.Duration
 
-	shouldRoute := h.alwaysRoute || !workerConnected
-
 	// Always route to other servers first, in case we're holding open a stale
 	// connection and the client has already reconnected to a different server.
+	shouldRoute := h.alwaysRoute || !workerConnected
+
 	if shouldRoute {
 		h.metrics.Increment("updates.routed.outgoing")
 		// Abort routing if the connection goes away.

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
@@ -330,9 +330,11 @@ func (h *EndpointHandler) deliver(cn http.CloseNotifier, uaid, chid string,
 	worker, workerConnected := h.app.GetWorker(uaid)
 	var routingTime time.Duration
 
+	shouldRoute := h.alwaysRoute || !workerConnected
+
 	// Always route to other servers first, in case we're holding open a stale
 	// connection and the client has already reconnected to a different server.
-	if h.alwaysRoute || !workerConnected {
+	if shouldRoute {
 		h.metrics.Increment("updates.routed.outgoing")
 		// Abort routing if the connection goes away.
 		var cancelSignal <-chan bool
@@ -344,41 +346,35 @@ func (h *EndpointHandler) deliver(cn http.CloseNotifier, uaid, chid string,
 		delivered, _ = h.router.Route(cancelSignal, uaid, chid, version,
 			startTime, requestID, data)
 		routingTime = timeNow().UTC().Sub(startTime)
+
+		// Increment appropriate metrics
+		if delivered {
+			h.metrics.Increment("router.broadcast.hit")
+			h.metrics.Timer("updates.routed.hits", routingTime)
+		} else {
+			h.metrics.Increment("router.broadcast.miss")
+			h.metrics.Timer("updates.routed.misses", routingTime)
+		}
 	}
 
-	// If we delivered the message
+	// Should we attempt local delivery? Only if the worker is connected
+	// and we either always route, or failed to remote deliver
+	shouldLocalDeliver := workerConnected && (h.alwaysRoute || !delivered)
+
+	if shouldLocalDeliver {
+		if err := worker.Send(chid, version, data); err == nil {
+			delivered = true
+		}
+	}
+
+	// Increment the appropriate final metric whether deliver did or
+	// did not work
 	if delivered {
-		h.metrics.Increment("router.broadcast.hit")
-		h.metrics.Timer("updates.routed.hits", routingTime)
-		// If we're not always routing, we're done now
-		if !h.alwaysRoute {
-			h.metrics.Increment("updates.appserver.received")
-			return true
-		}
-	} else if !workerConnected {
-		// Worker is not connected and routing failed
-		h.metrics.Increment("router.broadcast.miss")
-		h.metrics.Timer("updates.routed.misses", routingTime)
-		h.metrics.Increment("updates.appserver.rejected")
-		return false
-	}
-
-	// Possible conditions at this point:
-	// Router delivered, but alwaysRoute is true
-	// Router didn't deliver, alwaysRoute true or false
-
-	// Try local delivery
-	if err := worker.Send(chid, version, data); err == nil {
-		// Local delivery worked, avoid incrementing received if we
-		// also already delivered it
-		if !delivered {
-			h.metrics.Increment("updates.appserver.received")
-		}
-		delivered = true
-	} else if !delivered {
-		// Local delivery failed *and* routing failed
+		h.metrics.Increment("updates.appserver.received")
+	} else {
 		h.metrics.Increment("updates.appserver.rejected")
 	}
+
 	return delivered
 }
 

--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint_test.go
@@ -621,7 +621,7 @@ func TestEndpointDelivery(t *testing.T) {
 				So(ok, ShouldBeTrue)
 			})
 
-			Convey("And router delivery succeds, local fails", func() {
+			Convey("And router delivery succeeds, local fails", func() {
 				gomock.InOrder(
 					mckStat.EXPECT().Increment("updates.routed.outgoing"),
 					mckRouter.EXPECT().Route(nil, uaid, chid, version,


### PR DESCRIPTION
Regardless of alwaysRoute, previously if router delivery worked, local delivery wouldn't be tried. When fixing this I also noticed that the reject/received metrics failed to get properly updated under some routing conditions, this has been fixed and the tests updated to detect the metric.

Closes #232.