### PR TITLE
Add an option for building without libmemcached

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -15,7 +15,7 @@ github.com/coreos/go-etcd/etcd 6fe04d580dfb71c9e34cbce2f4df9eefd1e1241e
 github.com/glycerine/rbtree cd7940bb26b149ce2faf398e7c63fff01aa7b394
 github.com/gorilla/context 14f550f51af52180c2eefed15e5fd18d63c0a64a
 github.com/gorilla/mux 4b8fbc56f3b2400a7c7ea3dba9b3539787c486b6
-github.com/ianoshen/gomc 7b9f299f292d3dd707fe2749d966968c9bf1e128
+github.com/varstr/gomc 7b9f299f292d3dd707fe2749d966968c9bf1e128
 github.com/kitcambridge/envconf fdc1968532255bdb56182329cdaa1e5b9aa6a6ac
 github.com/smartystreets/goconvey 8298bc7d36389ffd3e57b85d9797850d8c2382a9
 github.com/jacobsa/oglematchers 4fc24f97b5b74022c2a3f4ca7eed57ca29083d3e

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ clean-cov:
 	rm -rf $(COVER_PATH)
 	rm -f $(COVER_HTML_TARGETS)
 
-$(COVER_PATH)/%.out: $(CURDIR)/src/%/*.go $(MOCKS)
+$(COVER_PATH)/%.out: $(CURDIR)/src/% $(MOCKS)
 	mkdir -p $(dir $@)
 	$(GO) test -tags smoke -covermode=$(COVER_MODE) -coverprofile=$@ $*
 

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ COVER_PACKAGES := $(addprefix $(COVER_PATH)/,\
 COVER_TARGETS := coverage.out coverage.server.out
 COVER_HTML_TARGETS := $(patsubst %.out,%.html,$(COVER_TARGETS))
 
-.PHONY: all build gen clean-gen $(TARGET) test-mocks clean-mocks test \
-	test-server test-gomc test-gomemcache check-cov travis-cov\
+.PHONY: all build gen clean-gen $(TARGET) $(TARGET)-no-gomc test-mocks\
+	clean-mocks test test-server test-gomc test-gomemcache check-cov travis-cov\
 	html-cov html-server-cov clean-cov bench bench-server vet clean
 .INTERMEDIATE: $(COVER_TARGETS)
 
@@ -97,9 +97,14 @@ memcached: libmemcached-1.0.18
 
 # Build the Simple Push server.
 $(TARGET):
-	rm -f $(TARGET)
+	rm -f $@
 	@echo "Building simplepush"
-	$(GO) build -tags libmemcached -o $(TARGET) $(PACKAGE)
+	$(GO) build -tags libmemcached -o $@ $(PACKAGE)
+
+$(TARGET)-no-gomc:
+	rm -f $@
+	@echo "Building simplepush without libmemcached"
+	$(GO) build -o $@ $(PACKAGE)
 
 # Generate mock interfaces for the tests.
 test-mocks: $(MOCKS)
@@ -178,4 +183,4 @@ vet:
 
 clean: clean-cov clean-mocks clean-gen
 	rm -rf bin $(DEPS)
-	rm -f $(TARGET)
+	rm -f $(TARGET) $(TARGET)-no-gomc

--- a/README.md
+++ b/README.md
@@ -26,22 +26,53 @@ You will need to have Go 1.3 or higher installed on your system, and the
 GOROOT and PATH should be set appropriately for 'go' to be found.
 
 ## Compiling
-To compile this server:
+Check out a working copy of the source code with Git:
 
-1. extract this directory into target directory
-2. Run: make
-3. Run: make simplepush
-4. Copy config.sample.toml to config.toml, and edit appropriately
+    git clone https://github.com/mozilla-services/pushgo.git
+    cd pushgo
 
-Step 3 should be re-run whenever code has been changed and the server
-should be recompiled.
+The server includes three adapters for offline storage: `memcache_gomc` and
+`memcache_memcachego`, which persist to memcached, and `dynamodb`, which
+persists to DynamoDB.
 
-If you would like to use an existing go on your system:
-1. Create a bin directory in the target directory
-2. Symlink your go binary into the bin directory you made
-3. Run the make commands starting at step 2 from above
+### memcached persistence
 
-This will build "simplepush" as an executable.
+The `memcache_gomc` adapter (`emcee_store.go`) binds to libmemcached via
+[gomc](http://godoc.org/github.com/varstr/gomc). This library provides a great
+deal of control over how the server communicates and uses memcache, however it
+does require compiling a local version of libmemcache, which can add difficulty.
+
+The `memcache_memcachego` adapter (`gomemc_store.go`) uses a golang based
+memcache client. While fully functional, we've not tested this under full load.
+
+### Custom compilers
+
+If you would like to build with a specific version of `go`, `protoc`,
+or `capnpc` on your system:
+
+1. Create a `bin` directory in the target directory
+2. Symlink the desired binary into the `bin` directory you made
+
+### Building
+
+To build the server with all storage adapters, run:
+
+    make
+    make simplepush
+
+To build the server **without the libmemcached adapter** (`memcache_gomc`),
+run:
+
+    make
+    make simplepush-no-gomc
+
+This will build a `simplepush` or `simplepush-no-gomc` executable, which you
+can run like so:
+
+    cp config.sample.toml config.toml
+    # Edit config.toml appropriately
+    ./simplepush -config=config.toml
+    # Or ./simplepush-no-gomc -config=config.toml
 
 ## Execution
  The server is built to run behind a SSL capable load balancer (e.g.
@@ -54,20 +85,6 @@ This server currently has no facility for UDP pings. This is a
 proprietary function (which, unsurprisingly, works remarkably poorly
 with non-local networks). There is currently no "dashboard" for
 element management.
-
-This server currently uses one of two methods to connect to memcache.
-memcache_gomc uses the store_emcee.go file, and ties to libmemcache.
-This library provides a great deal of control over how the server
-communicates and uses memcache, however it does require compiling
-a local version of libmemcache, which can add difficulty. The
-alternate method "memcache_memcachego", uses store_gomemc.go, and uses
-a golang based memcache client. While fully functional, we've not
-tested this under full load.
-
-If you wish, you can prevent either of these libraries from being
-compiled into your executable by changing the extension for either of
-these files from ".go" to ".go.skip". This may help you get a demo
-server running quickly.
 
 ## Use
 That's neat and all, but what does this do?

--- a/src/github.com/mozilla-services/pushgo/simplepush/emcee_store.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/emcee_store.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	mc "github.com/ianoshen/gomc"
+	mc "github.com/varstr/gomc"
 
 	"github.com/mozilla-services/pushgo/id"
 )


### PR DESCRIPTION
Also updated the build instructions, and `gomc` import path. I definitely remember @jrconlin's fix for this, but I don't see it in `git log Makefile` at all...maybe it was part of an older branch?

Closes #236.