### PR TITLE
Issue a new device ID if the client sends an invalid one

### DIFF
--- a/src/github.com/mozilla-services/pushgo/simplepush/api_smoke_test.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/api_smoke_test.go
@@ -308,62 +308,62 @@ func (t typeTest) Run() error {
 }
 
 var typeTests = []typeTest{
-	{"invalid device ID", "hello", "invalid_uaid", 503, true},
+	{name: "invalid device ID", messageType: "hello", deviceId: "invalid_uaid", statusCode: 200, shouldReset: true},
 
 	// Leading and trailing whitespace.
-	{"whitespace in device ID", "hello", " fooey barrey ", 503, true},
-	{"whitespace in message type", " fooey barrey ", validId, 401, true},
+	{name: "whitespace in device ID", messageType: "hello", deviceId: " fooey barrey ", statusCode: 200, shouldReset: true},
+	{name: "whitespace in message type", messageType: " fooey barrey ", deviceId: validId, statusCode: 401},
 
 	// Special characters.
-	{"special characters in device ID", "hello", `!@#$%^&*()-+`, 503, true},
-	{"special characters in message type", `!@#$%^&*()-+`, validId, 401, true},
+	{name: "special characters in device ID", messageType: "hello", deviceId: `!@#$%^&*()-+`, statusCode: 200, shouldReset: true},
+	{name: "special characters in message type", messageType: `!@#$%^&*()-+`, deviceId: validId, statusCode: 401},
 
 	// Integer strings.
-	{`device ID = "0"`, "hello", "0", 503, true},
-	{`message type = "0"`, "0", validId, 401, true},
-	{`device ID = "1"`, "hello", "1", 503, true},
-	{`message type = "1"`, "1", validId, 401, true},
+	{name: `device ID = "0"`, messageType: "hello", deviceId: "0", statusCode: 200, shouldReset: true},
+	{name: `message type = "0"`, messageType: "0", deviceId: validId, statusCode: 401},
+	{name: `device ID = "1"`, messageType: "hello", deviceId: "1", statusCode: 200, shouldReset: true},
+	{name: `message type = "1"`, messageType: "1", deviceId: validId, statusCode: 401},
 
 	// Integers.
-	{"device ID = 0", "hello", 0, 401, true},
-	{"message type = 0", 0, validId, 401, true},
-	{"device ID = 1", "hello", 1, 401, true},
-	{"message type = 1", 1, validId, 401, true},
+	{name: "device ID = 0", messageType: "hello", deviceId: 0, statusCode: 401},
+	{name: "message type = 0", messageType: 0, deviceId: validId, statusCode: 401},
+	{name: "device ID = 1", messageType: "hello", deviceId: 1, statusCode: 401},
+	{name: "message type = 1", messageType: 1, deviceId: validId, statusCode: 401},
 
 	// Negative integers.
-	{"negative integer string as device ID", "hello", "-66000", 503, true},
-	{"negative integer string as message type", "-66000", validId, 401, true},
-	{"negative integer as device ID", "hello", -66000, 401, true},
-	{"negative integer as message type", -66000, validId, 401, true},
+	{name: "negative integer string as device ID", messageType: "hello", deviceId: "-66000", statusCode: 200, shouldReset: true},
+	{name: "negative integer string as message type", messageType: "-66000", deviceId: validId, statusCode: 401},
+	{name: "negative integer as device ID", messageType: "hello", deviceId: -66000, statusCode: 401},
+	{name: "negative integer as message type", messageType: -66000, deviceId: validId, statusCode: 401},
 
 	// "True", "true", "False", and "false".
-	{`device ID = "True"`, "hello", "True", 503, true},
-	{`message type = "True"`, "True", validId, 401, true},
-	{`device ID = "true"`, "hello", "true", 503, true},
-	{`message type = "true"`, "true", validId, 401, true},
-	{`device ID = "False"`, "hello", "False", 503, true},
-	{`message type = "False"`, "False", validId, 401, true},
-	{`device ID = "false"`, "hello", "false", 503, true},
-	{`message type = "false"`, "false", validId, 401, true},
+	{name: `device ID = "True"`, messageType: "hello", deviceId: "True", statusCode: 200, shouldReset: true},
+	{name: `message type = "True"`, messageType: "True", deviceId: validId, statusCode: 401},
+	{name: `device ID = "true"`, messageType: "hello", deviceId: "true", statusCode: 200, shouldReset: true},
+	{name: `message type = "true"`, messageType: "true", deviceId: validId, statusCode: 401},
+	{name: `device ID = "False"`, messageType: "hello", deviceId: "False", statusCode: 200, shouldReset: true},
+	{name: `message type = "False"`, messageType: "False", deviceId: validId, statusCode: 401},
+	{name: `device ID = "false"`, messageType: "hello", deviceId: "false", statusCode: 200, shouldReset: true},
+	{name: `message type = "false"`, messageType: "false", deviceId: validId, statusCode: 401},
 
 	// `true` and `false`.
-	{"device ID = true", "hello", true, 401, true},
-	{"message type = true", true, validId, 401, true},
-	{"device ID = false", "hello", false, 401, true},
-	{"message type = false", false, validId, 401, true},
+	{name: "device ID = true", messageType: "hello", deviceId: true, statusCode: 401},
+	{name: "message type = true", messageType: true, deviceId: validId, statusCode: 401},
+	{name: "device ID = false", messageType: "hello", deviceId: false, statusCode: 401},
+	{name: "message type = false", messageType: false, deviceId: validId, statusCode: 401},
 
 	// "None", "null", "nil", and `nil`.
-	{`device ID = "None"`, "hello", "None", 503, true},
-	{`message type = "None"`, "None", validId, 401, true},
-	{`device ID = "null"`, "hello", "null", 503, true},
-	{`message type = "null"`, "null", validId, 401, true},
-	{`device ID = "nil"`, "hello", "nil", 503, true},
-	{`message type = "nil"`, "nil", validId, 401, true},
-	{"message type = nil", NilId, validId, 401, true},
+	{name: `device ID = "None"`, messageType: "hello", deviceId: "None", statusCode: 200, shouldReset: true},
+	{name: `message type = "None"`, messageType: "None", deviceId: validId, statusCode: 401},
+	{name: `device ID = "null"`, messageType: "hello", deviceId: "null", statusCode: 200, shouldReset: true},
+	{name: `message type = "null"`, messageType: "null", deviceId: validId, statusCode: 401},
+	{name: `device ID = "nil"`, messageType: "hello", deviceId: "nil", statusCode: 200, shouldReset: true},
+	{name: `message type = "nil"`, messageType: "nil", deviceId: validId, statusCode: 401},
+	{name: "message type = nil", messageType: NilId, deviceId: validId, statusCode: 401},
 
 	// Quoted strings.
-	{"quoted string as device ID", "hello", `"foo bar"`, 503, true},
-	{"quoted string as message type", `"foo bar"`, validId, 401, true},
+	{name: "quoted string as device ID", messageType: "hello", deviceId: `"foo bar"`, statusCode: 200, shouldReset: true},
+	{name: "quoted string as message type", messageType: `"foo bar"`, deviceId: validId, statusCode: 401},
 }
 
 func TestMessageTypes(t *testing.T) {
@@ -387,12 +387,12 @@ func TestMessageTypes(t *testing.T) {
 	defer removeExistsHook(missingId)
 
 	specialTypes := []typeTest{
-		{"long device ID", "hello", longId, 503, true},
-		{"long message type", longId, validId, 401, true},
+		{name: "long device ID", messageType: "hello", deviceId: longId, statusCode: 200, shouldReset: true},
+		{name: "long message type", messageType: longId, deviceId: validId, statusCode: 401},
 
-		{"existing device ID with channels", "hello", existingId, 200, false},
+		{name: "existing device ID with channels", messageType: "hello", deviceId: existingId, statusCode: 200, shouldReset: false},
 		// Sending channel IDs with an unknown device ID should return a new device ID.
-		{"unknown device ID with channels", "hello", missingId, 200, true},
+		{name: "unknown device ID with channels", messageType: "hello", deviceId: missingId, statusCode: 200, shouldReset: true},
 	}
 	for _, test := range specialTypes {
 		if err := test.Run(); err != nil {

--- a/src/github.com/mozilla-services/pushgo/simplepush/worker.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/worker.go
@@ -477,7 +477,7 @@ func (w *WorkerWS) handshake(request *HelloRequest) (
 			w.logger.Warn("worker", "Invalid character in UAID",
 				LogFields{"rid": w.logID})
 		}
-		return "", false, ErrInvalidID
+		goto forceReset
 	}
 	if !w.store.CanStore(len(request.ChannelIDs)) {
 		// are there a suspicious number of channels?


### PR DESCRIPTION
Previously, the handshake process closed the connection if the client sent an invalid ID. The Gecko client does
not currently detect non-200 responses or clear invalid IDs before reconnecting. This can trigger a reconnect loop if the `services.push.userAgentID` preference is set to an invalid value by a user (via `about:config`) or third-party Simple Push server (thespec recommends, but does not require, UUIDs).

This pull request relaxes the server behavior to just issue a new, valid device ID if the client supplies an invalid one.