### PR TITLE
Added CORS support for Put Updates

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -67,6 +67,8 @@ addr = ":8080"
 # server but the old connection has yet to time out for the server. (This,
 # sadly, happens a fair bit.)
 #always_route = false
+# Enable CORS support for PUT updates
+#enable_cors = false
 
 [endpoint.listener]
 addr = ":8081"


### PR DESCRIPTION
This was a request for tesit

* enabled via config.toml
  [endpoint]
  enable_cors = true

* defaults to "false" so that it's not enabled by accident in
  production.

@kitcambridge || @bbangert r?