### PR TITLE
Fix up CORS headers

### DIFF
--- a/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
+++ b/src/github.com/mozilla-services/pushgo/simplepush/handlers_endpoint.go
@@ -203,7 +203,8 @@ func (h *EndpointHandler) getUpdateParams(req *http.Request) (version int64, dat
 
 // -- REST
 func (h *EndpointHandler) addCorsHeaders(resp http.ResponseWriter) {
-	resp.Header().Add("Access-Control-Request-Method", "*")
+	resp.Header().Add("Access-Control-Allow-Origin", "*")
+	resp.Header().Add("Access-Control-Allow-Methods", "PUT, OPTIONS")
 }
 
 func (h *EndpointHandler) UpdateHandler(resp http.ResponseWriter, req *http.Request) {
@@ -243,6 +244,10 @@ func (h *EndpointHandler) UpdateHandler(resp http.ResponseWriter, req *http.Requ
 
 	if h.enableCors {
 		h.addCorsHeaders(resp)
+	}
+	if req.Method == "OPTIONS" {
+		resp.WriteHeader(http.StatusOK)
+		return
 	}
 
 	if req.Method != "PUT" {


### PR DESCRIPTION
* Send an `Access-Control-Allow-Origin` header, required for CORS support.
* Whitelist supported methods in `Access-Control-Allow-Methods`. It looks like the `"*"` syntax is only supported for the `*-Origin` headers.
* Respond with 200 (OK) to preflight requests; otherwise, the preflight request is assumed to have failed.

Tested this out with `XMLHttpRequest` locally.

@jrconlin r?